### PR TITLE
Multi-tenancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ integrate, quick to master and flexible enough to handle complex requirements.
 * ABAC, RBAC & ReBAC (with constraints)
 * Not just authorisation checks, list users, resources a user can access and users with access to a resource
 * First class treatment for listing endpoints with pagination and limits to handle large datasets
+* Multi-tenancy support, when you need it
 * Built using the fastest gRPC server implementation[^3]
 
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ integrate, quick to master and flexible enough to handle complex requirements.
 * ABAC, RBAC & ReBAC (with constraints)
 * Not just authorisation checks, list users, resources a user can access and users with access to a resource
 * First class treatment for listing endpoints with pagination and limits to handle large datasets
-* Multi-tenancy support, when you need it
+* Multi-tenancy support, if you need it
 * Built using the fastest gRPC server implementation[^3]
 
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,10 +1,11 @@
 create table if not exists principals (
-	_rev     integer not null,
+	space_id text    not null,
 	id       text    not null,
 	segment  text,
 	attrs    jsonb,
+	_rev     integer not null,
 
-	constraint "principals.pkey" primary key (id),
+	constraint "principals.pkey" primary key (space_id, id),
 	constraint "principals.check-segment" check (segment <> ''),
 	constraint "principals.check-attrs" check (jsonb_typeof(attrs) = 'object')
 );
@@ -12,15 +13,16 @@ create table if not exists principals (
 create index "principals.idx-segment" on principals using hash (segment);
 
 create table if not exists records (
-	_rev          integer not null,
+	space_id      text    not null,
 	principal_id  text    not null,
 	resource_type text    not null,
 	resource_id   text    not null,
 	attrs         jsonb,
+	_rev          integer not null,
 
-	constraint "records.pkey" primary key (principal_id, resource_type, resource_id),
-	constraint "records.fkey-principal_id" foreign key (principal_id)
-		references principals(id)
+	constraint "records.pkey" primary key (space_id, principal_id, resource_type, resource_id),
+	constraint "records.fkey-space_id+principal_id" foreign key (space_id, principal_id)
+		references principals(space_id, id)
 		on delete cascade,
 
 	constraint "records.check-resource_type" check (resource_type <> ''),

--- a/src/db/principals.h
+++ b/src/db/principals.h
@@ -16,6 +16,7 @@ public:
 		attrs_t     attrs;
 		std::string id;
 		segment_t   segment;
+		std::string spaceId;
 
 		bool operator==(const Data &) const noexcept = default;
 	};
@@ -41,11 +42,12 @@ public:
 
 	const std::string &id() const noexcept { return _data.id; }
 	const int         &rev() const noexcept { return _rev; }
+	const std::string &spaceId() const noexcept { return _data.spaceId; }
 
 	void store();
 
-	static bool      discard(const std::string &id);
-	static Principal retrieve(const std::string &id);
+	static bool      discard(std::string_view spaceId, const std::string &id);
+	static Principal retrieve(std::string_view spaceId, const std::string &id);
 
 private:
 	Data _data;
@@ -55,6 +57,6 @@ private:
 using Principals = std::vector<Principal>;
 
 Principals ListPrincipals(
-	Principal::Data::segment_t segment = std::nullopt, std::string_view lastId = "",
-	std::uint16_t count = 10);
+	std::string_view spaceId, Principal::Data::segment_t segment = std::nullopt,
+	std::string_view lastId = "", std::uint16_t count = 10);
 } // namespace db

--- a/src/db/records.cpp
+++ b/src/db/records.cpp
@@ -15,44 +15,48 @@ Record::Record(const pg::row_t &r) :
 		.principalId  = r["principal_id"].as<std::string>(),
 		.resourceId   = r["resource_id"].as<std::string>(),
 		.resourceType = r["resource_type"].as<std::string>(),
+		.spaceId      = r["space_id"].as<std::string>(),
 	}),
 	_rev(r["_rev"].as<int>()) {}
 
 bool Record::discard(
-	const std::string &principalId, const std::string &resourceType,
+	std::string_view spaceId, const std::string &principalId, const std::string &resourceType,
 	const std::string &resourceId) {
 	std::string_view qry = R"(
 		delete from records
 		where
-			principal_id = $1::text
-			and resource_type = $2::text
-			and resource_id = $3::text
+			space_id = $1::text
+			and principal_id = $2::text
+			and resource_type = $3::text
+			and resource_id = $4::text
 		;
 	)";
 
-	auto res = pg::exec(qry, principalId, resourceType, resourceId);
+	auto res = pg::exec(qry, spaceId, principalId, resourceType, resourceId);
 	return (res.affected_rows() == 1);
 }
 
 std::optional<Record> Record::lookup(
-	const std::string &principalId, const std::string &resourceType,
+	std::string_view spaceId, const std::string &principalId, const std::string &resourceType,
 	const std::string &resourceId) {
 	std::string_view qry = R"(
 		select
-			_rev,
+			space_id,
 			principal_id,
 			resource_type,
 			resource_id,
-			attrs
+			attrs,
+			_rev
 		from records
 		where
-			principal_id = $1::text
-			and resource_type = $2::text
-			and resource_id = $3::text
+			space_id = $1::text
+			and principal_id = $2::text
+			and resource_type = $3::text
+			and resource_id = $4::text
 		;
 	)";
 
-	auto res = pg::exec(qry, principalId, resourceType, resourceId);
+	auto res = pg::exec(qry, spaceId, principalId, resourceType, resourceId);
 	if (res.empty()) {
 		return std::nullopt;
 	}
@@ -63,35 +67,43 @@ std::optional<Record> Record::lookup(
 void Record::store() {
 	std::string_view qry = R"(
 		insert into records as t (
-			_rev,
+			space_id,
 			principal_id,
 			resource_type,
 			resource_id,
-			attrs
+			attrs,
+			_rev
 		) values (
-			$1::integer,
+			$1::text,
 			$2::text,
 			$3::text,
 			$4::text,
-			$5::jsonb
+			$5::jsonb,
+			$6::integer
 		)
-		on conflict (principal_id, resource_type, resource_id)
+		on conflict (space_id, principal_id, resource_type, resource_id)
 		do update
 			set (
-				_rev,
-				attrs
+				attrs,
+				_rev
 			) = (
-				excluded._rev + 1,
-				$5::jsonb
+				$5::jsonb,
+				excluded._rev + 1
 			)
-			where t._rev = $1::integer
+			where t._rev = $6::integer
 		returning _rev;
 	)";
 
 	pg::result_t res;
 	try {
 		res = pg::exec(
-			qry, _rev, _data.principalId, _data.resourceType, _data.resourceId, _data.attrs);
+			qry,
+			_data.spaceId,
+			_data.principalId,
+			_data.resourceType,
+			_data.resourceId,
+			_data.attrs,
+			_rev);
 	} catch (pqxx::check_violation &) {
 		throw err::DbRecordInvalidData();
 	} catch (pg::fkey_violation_t &) {
@@ -106,21 +118,23 @@ void Record::store() {
 }
 
 Records ListRecordsByPrincipal(
-	std::string_view principalId, std::string_view resourceType, std::string_view lastId,
-	std::uint16_t count) {
-	std::string where = "where principal_id = $1::text and resource_type = $2::text";
+	std::string_view spaceId, std::string_view principalId, std::string_view resourceType,
+	std::string_view lastId, std::uint16_t count) {
+	std::string where =
+		"where space_id = $1::text and principal_id = $2::text and resource_type = $3::text";
 	if (!lastId.empty()) {
-		where += " and resource_id < $3::text";
+		where += " and resource_id < $4::text";
 	}
 
 	const std::string qry = fmt::format(
 		R"(
 			select
-				_rev,
+				space_id,
 				principal_id,
 				resource_type,
 				resource_id,
-				attrs
+				attrs,
+				_rev
 			from records
 			{}
 			order by resource_id desc
@@ -131,9 +145,9 @@ Records ListRecordsByPrincipal(
 
 	db::pg::result_t res;
 	if (!lastId.empty()) {
-		res = pg::exec(qry, principalId, resourceType, lastId);
+		res = pg::exec(qry, spaceId, principalId, resourceType, lastId);
 	} else {
-		res = pg::exec(qry, principalId, resourceType);
+		res = pg::exec(qry, spaceId, principalId, resourceType);
 	}
 
 	Records records;
@@ -146,21 +160,23 @@ Records ListRecordsByPrincipal(
 }
 
 Records ListRecordsByResource(
-	std::string_view resourceType, std::string_view resourceId, std::string_view lastId,
-	std::uint16_t count) {
-	std::string where = "where resource_type = $1::text and resource_id = $2::text";
+	std::string_view spaceId, std::string_view resourceType, std::string_view resourceId,
+	std::string_view lastId, std::uint16_t count) {
+	std::string where =
+		"where space_id = $1::text and resource_type = $2::text and resource_id = $3::text";
 	if (!lastId.empty()) {
-		where += " and principal_id < $3::text";
+		where += " and principal_id < $4::text";
 	}
 
 	const std::string qry = fmt::format(
 		R"(
 			select
-				_rev,
+				space_id,
 				principal_id,
 				resource_type,
 				resource_id,
-				attrs
+				attrs,
+				_rev
 			from records
 			{}
 			order by principal_id desc
@@ -171,9 +187,9 @@ Records ListRecordsByResource(
 
 	db::pg::result_t res;
 	if (!lastId.empty()) {
-		res = pg::exec(qry, resourceType, resourceId, lastId);
+		res = pg::exec(qry, spaceId, resourceType, resourceId, lastId);
 	} else {
-		res = pg::exec(qry, resourceType, resourceId);
+		res = pg::exec(qry, spaceId, resourceType, resourceId);
 	}
 
 	Records records;

--- a/src/db/records.h
+++ b/src/db/records.h
@@ -16,6 +16,7 @@ public:
 		std::string principalId;
 		std::string resourceId;
 		std::string resourceType;
+		std::string spaceId;
 
 		bool operator==(const Data &) const noexcept = default;
 	};
@@ -36,17 +37,18 @@ public:
 	const std::string &principalId() const noexcept { return _data.principalId; }
 	const std::string &resourceId() const noexcept { return _data.resourceId; }
 	const std::string &resourceType() const noexcept { return _data.resourceType; }
+	const std::string &spaceId() const noexcept { return _data.spaceId; }
 
 	const int &rev() const noexcept { return _rev; }
 
 	void store();
 
 	static bool discard(
-		const std::string &principalId, const std::string &resourceType,
+		std::string_view spaceId, const std::string &principalId, const std::string &resourceType,
 		const std::string &resourceId);
 
 	static std::optional<Record> lookup(
-		const std::string &principalId, const std::string &resourceType,
+		std::string_view spaceId, const std::string &principalId, const std::string &resourceType,
 		const std::string &resourceId);
 
 private:
@@ -57,10 +59,10 @@ private:
 using Records = std::vector<Record>;
 
 Records ListRecordsByPrincipal(
-	std::string_view principalId, std::string_view resourceType, std::string_view lastId = "",
-	std::uint16_t count = 10);
+	std::string_view spaceId, std::string_view principalId, std::string_view resourceType,
+	std::string_view lastId = "", std::uint16_t count = 10);
 
 Records ListRecordsByResource(
-	std::string_view resourceType, std::string_view resourceId, std::string_view lastId = "",
-	std::uint16_t count = 10);
+	std::string_view spaceId, std::string_view resourceType, std::string_view resourceId,
+	std::string_view lastId = "", std::uint16_t count = 10);
 } // namespace db

--- a/src/db/records_test.cpp
+++ b/src/db/records_test.cpp
@@ -34,6 +34,7 @@ TEST_F(db_RecordsTest, discard) {
 		.principalId  = principal.id(),
 		.resourceId   = "discard",
 		.resourceType = "db_RecordsTest",
+		.spaceId      = principal.spaceId(),
 	});
 	ASSERT_NO_THROW(record.store());
 
@@ -73,6 +74,7 @@ TEST_F(db_RecordsTest, list) {
 		.principalId  = principal.id(),
 		.resourceId   = "list",
 		.resourceType = "db_RecordsTest",
+		.spaceId      = principal.spaceId(),
 	});
 	ASSERT_NO_THROW(record.store());
 
@@ -114,21 +116,25 @@ TEST_F(db_RecordsTest, list) {
 				.principalId  = principals[0].id(),
 				.resourceId   = "list-with_last_id[0]",
 				.resourceType = "db_RecordsTest",
+				.spaceId      = principals[0].spaceId(),
 			}},
 			{{
 				.principalId  = principals[1].id(),
 				.resourceId   = "list-with_last_id[0]",
 				.resourceType = "db_RecordsTest",
+				.spaceId      = principals[1].spaceId(),
 			}},
 			{{
 				.principalId  = principals[0].id(),
 				.resourceId   = "list-with_last_id[1]",
 				.resourceType = "db_RecordsTest",
+				.spaceId      = principals[0].spaceId(),
 			}},
 			{{
 				.principalId  = principals[1].id(),
 				.resourceId   = "list-with_last_id[1]",
 				.resourceType = "db_RecordsTest",
+				.spaceId      = principals[1].spaceId(),
 			}},
 		});
 
@@ -178,6 +184,7 @@ TEST_F(db_RecordsTest, lookup) {
 		.principalId  = principal.id(),
 		.resourceId   = "lookup",
 		.resourceType = "db_RecordsTest",
+		.spaceId      = principal.spaceId(),
 	});
 	ASSERT_NO_THROW(record.store());
 
@@ -210,6 +217,7 @@ TEST_F(db_RecordsTest, rev) {
 			.principalId  = principal.id(),
 			.resourceId   = "rev",
 			.resourceType = "db_RecordsTest",
+			.spaceId      = principal.spaceId(),
 		});
 
 		ASSERT_NO_THROW(record.store());
@@ -225,6 +233,7 @@ TEST_F(db_RecordsTest, rev) {
 			.principalId  = principal.id(),
 			.resourceId   = "rev-mismatch",
 			.resourceType = "db_RecordsTest",
+			.spaceId      = principal.spaceId(),
 		});
 
 		std::string_view qry = R"(
@@ -267,6 +276,7 @@ TEST_F(db_RecordsTest, store) {
 			.principalId  = principal.id(),
 			.resourceId   = "store",
 			.resourceType = "db_RecordsTest",
+			.spaceId      = principal.spaceId(),
 		});
 		ASSERT_NO_THROW(record.store());
 
@@ -311,6 +321,7 @@ TEST_F(db_RecordsTest, store) {
 			.principalId  = principal.id(),
 			.resourceId   = "store",
 			.resourceType = "db_RecordsTest",
+			.spaceId      = principal.spaceId(),
 		});
 		ASSERT_NO_THROW(record.store());
 
@@ -337,12 +348,25 @@ TEST_F(db_RecordsTest, store) {
 		EXPECT_EQ(R"(["test"])", tags);
 	}
 
+	// Error: invalid `spaceId`
+	{
+		db::Record record({
+			.principalId  = principal.id(),
+			.resourceId   = "store-invalid_space_id",
+			.resourceType = "db_RecordsTest",
+			.spaceId      = "space_id:db_RecordsTest.store-invalid_space_id",
+		});
+
+		EXPECT_THROW(record.store(), err::DbRecordInvalidPrincipalId);
+	}
+
 	// Error: invalid `principalId`
 	{
 		db::Record record({
-			.principalId  = "id:db_RecordsTest.store-invalid-principalId",
-			.resourceId   = "store-invalid-principalId",
+			.principalId  = "id:db_RecordsTest.store-invalid_principal_id",
+			.resourceId   = "store-invalid_principal_id",
 			.resourceType = "db_RecordsTest",
+			.spaceId      = principal.spaceId(),
 		});
 
 		EXPECT_THROW(record.store(), err::DbRecordInvalidPrincipalId);
@@ -353,8 +377,9 @@ TEST_F(db_RecordsTest, store) {
 		db::Record record({
 			.attrs        = R"("string")",
 			.principalId  = principal.id(),
-			.resourceId   = "store-invalid-attrs",
+			.resourceId   = "store-invalid_attrs",
 			.resourceType = "db_RecordsTest",
+			.spaceId      = principal.spaceId(),
 		});
 
 		EXPECT_THROW(record.store(), err::DbRecordInvalidData);

--- a/src/svc/CMakeLists.txt
+++ b/src/svc/CMakeLists.txt
@@ -12,6 +12,10 @@ target_sources(svc
 			resources.h
 			svc.h
 			wrapper.h
+	PRIVATE
+		FILE_SET private_headers TYPE HEADERS
+		FILES
+			common.h
 )
 
 target_link_libraries(svc

--- a/src/svc/authz.cpp
+++ b/src/svc/authz.cpp
@@ -5,13 +5,15 @@
 
 #include "err/errors.h"
 
+#include "common.h"
+
 namespace svc {
 namespace authz {
 template <>
 rpcCheck::result_type Impl::call<rpcCheck>(
 	grpcxx::context &ctx, const rpcCheck::request_type &req) {
 	auto r = db::Record::lookup(
-		ctx.meta("space-id"), req.principal_id(), req.resource_type(), req.resource_id());
+		ctx.meta(common::space_id_v), req.principal_id(), req.resource_type(), req.resource_id());
 	return {grpcxx::status::code_t::ok, map(r)};
 }
 
@@ -20,7 +22,10 @@ rpcGrant::result_type Impl::call<rpcGrant>(
 	grpcxx::context &ctx, const rpcGrant::request_type &req) {
 	// Upsert if exists
 	if (auto r = db::Record::lookup(
-			ctx.meta("space-id"), req.principal_id(), req.resource_type(), req.resource_id());
+			ctx.meta(common::space_id_v),
+			req.principal_id(),
+			req.resource_type(),
+			req.resource_id());
 		r) {
 		if (req.has_attrs()) {
 			std::string attrs;
@@ -43,7 +48,7 @@ template <>
 rpcRevoke::result_type Impl::call<rpcRevoke>(
 	grpcxx::context &ctx, const rpcRevoke::request_type &req) {
 	db::Record::discard(
-		ctx.meta("space-id"), req.principal_id(), req.resource_type(), req.resource_id());
+		ctx.meta(common::space_id_v), req.principal_id(), req.resource_type(), req.resource_id());
 	return {grpcxx::status::code_t::ok, rpcRevoke::response_type()};
 }
 
@@ -76,7 +81,7 @@ db::Record Impl::map(
 		.principalId  = from.principal_id(),
 		.resourceId   = from.resource_id(),
 		.resourceType = from.resource_type(),
-		.spaceId      = std::string(ctx.meta("space-id")),
+		.spaceId      = std::string(ctx.meta(common::space_id_v)),
 	});
 
 	if (from.has_attrs()) {

--- a/src/svc/authz.cpp
+++ b/src/svc/authz.cpp
@@ -10,7 +10,8 @@ namespace authz {
 template <>
 rpcCheck::result_type Impl::call<rpcCheck>(
 	grpcxx::context &ctx, const rpcCheck::request_type &req) {
-	auto r = db::Record::lookup(req.principal_id(), req.resource_type(), req.resource_id());
+	auto r = db::Record::lookup(
+		ctx.meta("space-id"), req.principal_id(), req.resource_type(), req.resource_id());
 	return {grpcxx::status::code_t::ok, map(r)};
 }
 
@@ -18,7 +19,8 @@ template <>
 rpcGrant::result_type Impl::call<rpcGrant>(
 	grpcxx::context &ctx, const rpcGrant::request_type &req) {
 	// Upsert if exists
-	if (auto r = db::Record::lookup(req.principal_id(), req.resource_type(), req.resource_id());
+	if (auto r = db::Record::lookup(
+			ctx.meta("space-id"), req.principal_id(), req.resource_type(), req.resource_id());
 		r) {
 		if (req.has_attrs()) {
 			std::string attrs;
@@ -31,7 +33,7 @@ rpcGrant::result_type Impl::call<rpcGrant>(
 		return {grpcxx::status::code_t::ok, map(r.value())};
 	}
 
-	auto r = map(req);
+	auto r = map(ctx, req);
 	r.store();
 
 	return {grpcxx::status::code_t::ok, map(r)};
@@ -40,7 +42,8 @@ rpcGrant::result_type Impl::call<rpcGrant>(
 template <>
 rpcRevoke::result_type Impl::call<rpcRevoke>(
 	grpcxx::context &ctx, const rpcRevoke::request_type &req) {
-	db::Record::discard(req.principal_id(), req.resource_type(), req.resource_id());
+	db::Record::discard(
+		ctx.meta("space-id"), req.principal_id(), req.resource_type(), req.resource_id());
 	return {grpcxx::status::code_t::ok, rpcRevoke::response_type()};
 }
 
@@ -67,11 +70,13 @@ google::rpc::Status Impl::exception() noexcept {
 	return status;
 }
 
-db::Record Impl::map(const rpcGrant::request_type &from) const noexcept {
+db::Record Impl::map(
+	const grpcxx::context &ctx, const rpcGrant::request_type &from) const noexcept {
 	db::Record to({
 		.principalId  = from.principal_id(),
 		.resourceId   = from.resource_id(),
 		.resourceType = from.resource_type(),
+		.spaceId      = std::string(ctx.meta("space-id")),
 	});
 
 	if (from.has_attrs()) {

--- a/src/svc/authz.h
+++ b/src/svc/authz.h
@@ -32,7 +32,7 @@ public:
 private:
 	rpcCheck::response_type map(const std::optional<db::Record> &from) const noexcept;
 
-	db::Record              map(const rpcGrant::request_type &from) const noexcept;
+	db::Record map(const grpcxx::context &ctx, const rpcGrant::request_type &from) const noexcept;
 	rpcGrant::response_type map(const db::Record &from) const noexcept;
 };
 } // namespace authz

--- a/src/svc/authz_test.cpp
+++ b/src/svc/authz_test.cpp
@@ -1,4 +1,5 @@
 #include <google/protobuf/util/json_util.h>
+#include <grpcxx/request.h>
 #include <gtest/gtest.h>
 
 #include "db/testing.h"
@@ -35,6 +36,7 @@ TEST_F(svc_AuthzTest, Check) {
 			.principalId  = principal.id(),
 			.resourceId   = "Check",
 			.resourceType = "svc_AuthzTest",
+			.spaceId      = principal.spaceId(),
 		});
 		ASSERT_NO_THROW(record.store());
 
@@ -59,6 +61,7 @@ TEST_F(svc_AuthzTest, Check) {
 			.principalId  = principal.id(),
 			.resourceId   = "Check-with_attrs",
 			.resourceType = "svc_AuthzTest",
+			.spaceId      = principal.spaceId(),
 		});
 		ASSERT_NO_THROW(record.store());
 
@@ -79,12 +82,76 @@ TEST_F(svc_AuthzTest, Check) {
 		EXPECT_EQ(record.attrs(), responseAttrs);
 	}
 
+	// Success: check with space-id
+	{
+		db::Principal principal({
+			.id      = "id:svc_AuthzTest.Check",
+			.spaceId = "space_id:svc_AuthzTest.Check",
+		});
+		ASSERT_NO_THROW(principal.store());
+
+		db::Record record({
+			.principalId  = principal.id(),
+			.resourceId   = "Check-with_space_id",
+			.resourceType = "svc_AuthzTest",
+			.spaceId      = principal.spaceId(),
+		});
+		ASSERT_NO_THROW(record.store());
+
+		grpcxx::detail::request r(1);
+		r.header("space-id", std::string(principal.spaceId()));
+
+		grpcxx::context ctx(r);
+
+		rpcCheck::request_type request;
+		request.set_principal_id(record.principalId());
+		request.set_resource_type(record.resourceType());
+		request.set_resource_id(record.resourceId());
+
+		rpcCheck::result_type result;
+		EXPECT_NO_THROW(result = svc.call<rpcCheck>(ctx, request));
+		EXPECT_EQ(grpcxx::status::code_t::ok, result.status.code());
+		ASSERT_TRUE(result.response);
+
+		EXPECT_TRUE(result.response->ok());
+		EXPECT_FALSE(result.response->has_attrs());
+	}
+
 	// Success: check !ok
 	{
 		rpcCheck::request_type request;
 		request.set_principal_id("non-existent");
 		request.set_resource_type("svc_AuthzTest");
 		request.set_resource_id("Check-non_existent");
+
+		rpcCheck::result_type result;
+		EXPECT_NO_THROW(result = svc.call<rpcCheck>(ctx, request));
+		EXPECT_EQ(grpcxx::status::code_t::ok, result.status.code());
+		ASSERT_TRUE(result.response);
+
+		EXPECT_FALSE(result.response->ok());
+		EXPECT_FALSE(result.response->has_attrs());
+	}
+
+	// Success: check !ok with space-id
+	{
+		db::Record record({
+			.principalId  = principal.id(),
+			.resourceId   = "Check-space_id_mismatch",
+			.resourceType = "svc_AuthzTest",
+			.spaceId      = principal.spaceId(),
+		});
+		ASSERT_NO_THROW(record.store());
+
+		grpcxx::detail::request r(1);
+		r.header("space-id", "invalid");
+
+		grpcxx::context ctx(r);
+
+		rpcCheck::request_type request;
+		request.set_principal_id(record.principalId());
+		request.set_resource_type(record.resourceType());
+		request.set_resource_id(record.resourceId());
 
 		rpcCheck::result_type result;
 		EXPECT_NO_THROW(result = svc.call<rpcCheck>(ctx, request));
@@ -119,12 +186,38 @@ TEST_F(svc_AuthzTest, Grant) {
 		ASSERT_TRUE(result.response);
 	}
 
+	// Success: grant with space-id
+	{
+		db::Principal principal({
+			.id      = "id:svc_AuthzTest.Grant-with_space_id",
+			.spaceId = "space_id:svc_AuthzTest.Grant-with_space_id",
+		});
+		ASSERT_NO_THROW(principal.store());
+
+		grpcxx::detail::request r(1);
+		r.header("space-id", std::string(principal.spaceId()));
+
+		grpcxx::context ctx(r);
+
+		rpcGrant::request_type request;
+		request.set_principal_id(principal.id());
+		request.set_resource_type("svc_AuthzTest");
+		request.set_resource_id("Grant-with_space_id");
+
+		rpcGrant::result_type result;
+		EXPECT_NO_THROW(result = svc.call<rpcGrant>(ctx, request));
+
+		EXPECT_EQ(grpcxx::status::code_t::ok, result.status.code());
+		ASSERT_TRUE(result.response);
+	}
+
 	// Success: upsert
 	{
 		db::Record record({
 			.principalId  = principal.id(),
 			.resourceId   = "Grant-upsert",
 			.resourceType = "svc_AuthzTest",
+			.spaceId      = principal.spaceId(),
 		});
 		ASSERT_NO_THROW(record.store());
 
@@ -165,7 +258,26 @@ TEST_F(svc_AuthzTest, Grant) {
 		rpcGrant::request_type request;
 		request.set_principal_id("invalid");
 		request.set_resource_type("svc_AuthzTest");
-		request.set_resource_id("Grant-invalid:principal_id");
+		request.set_resource_id("Grant-invalid_principal_id");
+
+		rpcGrant::result_type result;
+		EXPECT_NO_THROW(result = svc.call<rpcGrant>(ctx, request));
+
+		EXPECT_EQ(grpcxx::status::code_t::invalid_argument, result.status.code());
+		ASSERT_FALSE(result.response);
+	}
+
+	// Error: invalid space-id
+	{
+		grpcxx::detail::request r(1);
+		r.header("space-id", "invalid");
+
+		grpcxx::context ctx(r);
+
+		rpcGrant::request_type request;
+		request.set_principal_id(principal.id());
+		request.set_resource_type("svc_AuthzTest");
+		request.set_resource_id("Grant-invalid_space_id");
 
 		rpcGrant::result_type result;
 		EXPECT_NO_THROW(result = svc.call<rpcGrant>(ctx, request));
@@ -190,6 +302,7 @@ TEST_F(svc_AuthzTest, Revoke) {
 			.principalId  = principal.id(),
 			.resourceId   = "Revoke",
 			.resourceType = "svc_AuthzTest",
+			.spaceId      = principal.spaceId(),
 		});
 		ASSERT_NO_THROW(record.store());
 
@@ -205,6 +318,36 @@ TEST_F(svc_AuthzTest, Revoke) {
 		ASSERT_TRUE(result.response);
 
 		EXPECT_FALSE(db::Record::lookup(
+			record.spaceId(), record.principalId(), record.resourceType(), record.resourceId()));
+	}
+
+	// Success: invalid space-id
+	{
+		db::Record record({
+			.principalId  = principal.id(),
+			.resourceId   = "Revoke-invalid_space_id",
+			.resourceType = "svc_AuthzTest",
+			.spaceId      = principal.spaceId(),
+		});
+		ASSERT_NO_THROW(record.store());
+
+		grpcxx::detail::request r(1);
+		r.header("space-id", "invalid");
+
+		grpcxx::context ctx(r);
+
+		rpcRevoke::request_type request;
+		request.set_principal_id(record.principalId());
+		request.set_resource_type(record.resourceType());
+		request.set_resource_id(record.resourceId());
+
+		rpcRevoke::result_type result;
+		EXPECT_NO_THROW(result = svc.call<rpcRevoke>(ctx, request));
+
+		EXPECT_EQ(grpcxx::status::code_t::ok, result.status.code());
+		ASSERT_TRUE(result.response);
+
+		EXPECT_TRUE(db::Record::lookup(
 			record.spaceId(), record.principalId(), record.resourceType(), record.resourceId()));
 	}
 }

--- a/src/svc/authz_test.cpp
+++ b/src/svc/authz_test.cpp
@@ -142,8 +142,8 @@ TEST_F(svc_AuthzTest, Grant) {
 		EXPECT_EQ(grpcxx::status::code_t::ok, result.status.code());
 		ASSERT_TRUE(result.response);
 
-		auto actual =
-			db::Record::lookup(record.principalId(), record.resourceType(), record.resourceId());
+		auto actual = db::Record::lookup(
+			record.spaceId(), record.principalId(), record.resourceType(), record.resourceId());
 		EXPECT_EQ(record.rev() + 1, actual->rev());
 		EXPECT_EQ(R"({"foo": "bar"})", actual->attrs());
 	}
@@ -204,7 +204,7 @@ TEST_F(svc_AuthzTest, Revoke) {
 		EXPECT_EQ(grpcxx::status::code_t::ok, result.status.code());
 		ASSERT_TRUE(result.response);
 
-		EXPECT_FALSE(
-			db::Record::lookup(record.principalId(), record.resourceType(), record.resourceId()));
+		EXPECT_FALSE(db::Record::lookup(
+			record.spaceId(), record.principalId(), record.resourceType(), record.resourceId()));
 	}
 }

--- a/src/svc/authz_test.cpp
+++ b/src/svc/authz_test.cpp
@@ -4,6 +4,7 @@
 
 #include "db/testing.h"
 
+#include "common.h"
 #include "svc.h"
 
 using namespace sentium::api::v1::Authz;
@@ -99,7 +100,7 @@ TEST_F(svc_AuthzTest, Check) {
 		ASSERT_NO_THROW(record.store());
 
 		grpcxx::detail::request r(1);
-		r.header("space-id", std::string(principal.spaceId()));
+		r.header(std::string(svc::common::space_id_v), std::string(principal.spaceId()));
 
 		grpcxx::context ctx(r);
 
@@ -144,7 +145,7 @@ TEST_F(svc_AuthzTest, Check) {
 		ASSERT_NO_THROW(record.store());
 
 		grpcxx::detail::request r(1);
-		r.header("space-id", "invalid");
+		r.header(std::string(svc::common::space_id_v), "invalid");
 
 		grpcxx::context ctx(r);
 
@@ -195,7 +196,7 @@ TEST_F(svc_AuthzTest, Grant) {
 		ASSERT_NO_THROW(principal.store());
 
 		grpcxx::detail::request r(1);
-		r.header("space-id", std::string(principal.spaceId()));
+		r.header(std::string(svc::common::space_id_v), std::string(principal.spaceId()));
 
 		grpcxx::context ctx(r);
 
@@ -270,7 +271,7 @@ TEST_F(svc_AuthzTest, Grant) {
 	// Error: invalid space-id
 	{
 		grpcxx::detail::request r(1);
-		r.header("space-id", "invalid");
+		r.header(std::string(svc::common::space_id_v), "invalid");
 
 		grpcxx::context ctx(r);
 
@@ -332,7 +333,7 @@ TEST_F(svc_AuthzTest, Revoke) {
 		ASSERT_NO_THROW(record.store());
 
 		grpcxx::detail::request r(1);
-		r.header("space-id", "invalid");
+		r.header(std::string(svc::common::space_id_v), "invalid");
 
 		grpcxx::context ctx(r);
 

--- a/src/svc/common.h
+++ b/src/svc/common.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <string_view>
+
+namespace svc {
+namespace common {
+static constexpr std::string_view space_id_v = "space-id";
+}
+} // namespace svc

--- a/src/svc/principals.cpp
+++ b/src/svc/principals.cpp
@@ -14,7 +14,7 @@ rpcCreate::result_type Impl::call<rpcCreate>(
 	grpcxx::context &ctx, const rpcCreate::request_type &req) {
 	if (req.has_id()) {
 		try {
-			db::Principal::retrieve(req.id());
+			db::Principal::retrieve(ctx.meta("space-id"), req.id());
 
 			throw err::RpcPrincipalsAlreadyExists();
 		} catch (const err::DbPrincipalNotFound &) {
@@ -22,7 +22,7 @@ rpcCreate::result_type Impl::call<rpcCreate>(
 		}
 	}
 
-	auto p = map(req);
+	auto p = map(ctx, req);
 	p.store();
 
 	return {grpcxx::status::code_t::ok, map(p)};
@@ -31,7 +31,7 @@ rpcCreate::result_type Impl::call<rpcCreate>(
 template <>
 rpcDelete::result_type Impl::call<rpcDelete>(
 	grpcxx::context &ctx, const rpcDelete::request_type &req) {
-	if (auto r = db::Principal::discard(req.id()); r == false) {
+	if (auto r = db::Principal::discard(ctx.meta("space-id"), req.id()); r == false) {
 		throw err::RpcPrincipalsNotFound();
 	}
 
@@ -58,7 +58,7 @@ rpcList::result_type Impl::call<rpcList>(grpcxx::context &ctx, const rpcList::re
 		limit = req.pagination_limit();
 	}
 
-	auto results  = db::ListPrincipals(segment, lastId, limit);
+	auto results  = db::ListPrincipals(ctx.meta("space-id"), segment, lastId, limit);
 	auto response = map(results);
 
 	if (results.size() == limit) {
@@ -75,14 +75,14 @@ rpcList::result_type Impl::call<rpcList>(grpcxx::context &ctx, const rpcList::re
 template <>
 rpcRetrieve::result_type Impl::call<rpcRetrieve>(
 	grpcxx::context &ctx, const rpcRetrieve::request_type &req) {
-	auto p = db::Principal::retrieve(req.id());
+	auto p = db::Principal::retrieve(ctx.meta("space-id"), req.id());
 	return {grpcxx::status::code_t::ok, map(p)};
 }
 
 template <>
 rpcUpdate::result_type Impl::call<rpcUpdate>(
 	grpcxx::context &ctx, const rpcUpdate::request_type &req) {
-	auto p = db::Principal::retrieve(req.id());
+	auto p = db::Principal::retrieve(ctx.meta("space-id"), req.id());
 	if (!req.has_attrs() && !req.has_segment()) {
 		// Nothing to update
 		return {grpcxx::status::code_t::ok, map(p)};
@@ -132,9 +132,11 @@ google::rpc::Status Impl::exception() noexcept {
 	return status;
 }
 
-db::Principal Impl::map(const rpcCreate::request_type &from) const noexcept {
+db::Principal Impl::map(
+	const grpcxx::context &ctx, const rpcCreate::request_type &from) const noexcept {
 	db::Principal to({
-		.id = from.id(),
+		.spaceId = std::string(ctx.meta("space-id")),
+		.id      = from.id(),
 	});
 
 	if (from.has_attrs()) {

--- a/src/svc/principals.h
+++ b/src/svc/principals.h
@@ -40,7 +40,8 @@ public:
 	google::rpc::Status exception() noexcept;
 
 private:
-	db::Principal map(const rpcCreate::request_type &from) const noexcept;
+	db::Principal map(
+		const grpcxx::context &ctx, const rpcCreate::request_type &from) const noexcept;
 
 	rpcCreate::response_type map(const db::Principal &from) const noexcept;
 	rpcList::response_type   map(const db::Principals &from) const noexcept;

--- a/src/svc/principals_test.cpp
+++ b/src/svc/principals_test.cpp
@@ -361,7 +361,7 @@ TEST_F(svc_PrincipalsTest, Update) {
 		EXPECT_FALSE(actual.has_segment());
 		EXPECT_FALSE(actual.has_attrs());
 
-		auto p = db::Principal::retrieve(principal.id());
+		auto p = db::Principal::retrieve(principal.spaceId(), principal.id());
 		EXPECT_EQ(principal.rev(), p.rev());
 	}
 }

--- a/src/svc/principals_test.cpp
+++ b/src/svc/principals_test.cpp
@@ -4,6 +4,7 @@
 
 #include "db/testing.h"
 
+#include "common.h"
 #include "svc.h"
 
 using namespace sentium::api::v1::Principals;
@@ -83,7 +84,9 @@ TEST_F(svc_PrincipalsTest, Create) {
 	// Success: create principal with space-id
 	{
 		grpcxx::detail::request r(1);
-		r.header("space-id", "space_id:svc_PrincipalsTest.Create-with_space_id");
+		r.header(
+			std::string(svc::common::space_id_v),
+			"space_id:svc_PrincipalsTest.Create-with_space_id");
 
 		grpcxx::context ctx(r);
 
@@ -157,7 +160,7 @@ TEST_F(svc_PrincipalsTest, Delete) {
 		ASSERT_NO_THROW(principal.store());
 
 		grpcxx::detail::request r(1);
-		r.header("space-id", std::string(principal.spaceId()));
+		r.header(std::string(svc::common::space_id_v), std::string(principal.spaceId()));
 
 		grpcxx::context ctx(r);
 
@@ -189,7 +192,7 @@ TEST_F(svc_PrincipalsTest, Delete) {
 		ASSERT_NO_THROW(principal.store());
 
 		grpcxx::detail::request r(1);
-		r.header("space-id", "invalid");
+		r.header(std::string(svc::common::space_id_v), "invalid");
 
 		grpcxx::context ctx(r);
 
@@ -245,7 +248,7 @@ TEST_F(svc_PrincipalsTest, List) {
 		}
 
 		grpcxx::detail::request r(1);
-		r.header("space-id", std::string(principals[0].spaceId()));
+		r.header(std::string(svc::common::space_id_v), std::string(principals[0].spaceId()));
 
 		grpcxx::context ctx(r);
 
@@ -376,7 +379,7 @@ TEST_F(svc_PrincipalsTest, Retrieve) {
 		ASSERT_NO_THROW(principal.store());
 
 		grpcxx::detail::request r(1);
-		r.header("space-id", std::string(principal.spaceId()));
+		r.header(std::string(svc::common::space_id_v), std::string(principal.spaceId()));
 
 		grpcxx::context ctx(r);
 
@@ -498,7 +501,7 @@ TEST_F(svc_PrincipalsTest, Update) {
 		ASSERT_NO_THROW(principal.store());
 
 		grpcxx::detail::request r(1);
-		r.header("space-id", "invalid");
+		r.header(std::string(svc::common::space_id_v), "invalid");
 
 		grpcxx::context ctx(r);
 

--- a/src/svc/resources.cpp
+++ b/src/svc/resources.cpp
@@ -23,8 +23,8 @@ rpcList::result_type Impl::call<rpcList>(grpcxx::context &ctx, const rpcList::re
 		limit = req.pagination_limit();
 	}
 
-	auto results =
-		db::ListRecordsByPrincipal(req.principal_id(), req.resource_type(), lastId, limit);
+	auto results = db::ListRecordsByPrincipal(
+		ctx.meta("space-id"), req.principal_id(), req.resource_type(), lastId, limit);
 
 	auto response = map<rpcList::response_type>(results);
 	if (results.size() == limit) {
@@ -54,7 +54,8 @@ rpcListPrincipals::result_type Impl::call<rpcListPrincipals>(
 		limit = req.pagination_limit();
 	}
 
-	auto results = db::ListRecordsByResource(req.resource_type(), req.resource_id(), lastId, limit);
+	auto results = db::ListRecordsByResource(
+		ctx.meta("space-id"), req.resource_type(), req.resource_id(), lastId, limit);
 	auto response = map<rpcListPrincipals::response_type>(results);
 
 	if (results.size() == limit) {

--- a/src/svc/resources.cpp
+++ b/src/svc/resources.cpp
@@ -6,6 +6,8 @@
 #include "encoding/b32.h"
 #include "sentium/detail/pagination.pb.h"
 
+#include "common.h"
+
 namespace svc {
 namespace resources {
 template <>
@@ -24,7 +26,7 @@ rpcList::result_type Impl::call<rpcList>(grpcxx::context &ctx, const rpcList::re
 	}
 
 	auto results = db::ListRecordsByPrincipal(
-		ctx.meta("space-id"), req.principal_id(), req.resource_type(), lastId, limit);
+		ctx.meta(common::space_id_v), req.principal_id(), req.resource_type(), lastId, limit);
 
 	auto response = map<rpcList::response_type>(results);
 	if (results.size() == limit) {
@@ -55,7 +57,7 @@ rpcListPrincipals::result_type Impl::call<rpcListPrincipals>(
 	}
 
 	auto results = db::ListRecordsByResource(
-		ctx.meta("space-id"), req.resource_type(), req.resource_id(), lastId, limit);
+		ctx.meta(common::space_id_v), req.resource_type(), req.resource_id(), lastId, limit);
 	auto response = map<rpcListPrincipals::response_type>(results);
 
 	if (results.size() == limit) {

--- a/src/svc/resources_test.cpp
+++ b/src/svc/resources_test.cpp
@@ -4,6 +4,7 @@
 
 #include "db/testing.h"
 
+#include "common.h"
 #include "svc.h"
 
 using namespace sentium::api::v1::Resources;
@@ -76,7 +77,7 @@ TEST_F(svc_ResourcesTest, List) {
 		ASSERT_NO_THROW(record.store());
 
 		grpcxx::detail::request r(1);
-		r.header("space-id", std::string(principal.spaceId()));
+		r.header(std::string(svc::common::space_id_v), std::string(principal.spaceId()));
 
 		grpcxx::context ctx(r);
 
@@ -217,7 +218,7 @@ TEST_F(svc_ResourcesTest, ListPrincipals) {
 		ASSERT_NO_THROW(record.store());
 
 		grpcxx::detail::request r(1);
-		r.header("space-id", "invalid");
+		r.header(std::string(svc::common::space_id_v), "invalid");
 
 		grpcxx::context ctx(r);
 


### PR DESCRIPTION
Use `space-id` gRPC metadata (i.e. HTTP/2 header) to create data silos to support multi-tenancy. 