### PR TITLE
Change Authz service to use tuples instead of records

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -77,5 +77,7 @@ create table if not exists tuples (
 		references principals(space_id, id)
 		on delete cascade,
 
+	constraint "tuples.check-l_entity_id" check (l_entity_id <> ''),
+	constraint "tuples.check-r_entity_id" check (r_entity_id <> ''),
 	constraint "tuples.check-attrs" check (jsonb_typeof(attrs) = 'object')
 );

--- a/src/db/tuples.cpp
+++ b/src/db/tuples.cpp
@@ -64,7 +64,7 @@ std::optional<Tuple> Tuple::lookup(
 	return Tuple(res[0]);
 }
 
-Tuple Tuple::retrieve(const std::string &id) {
+Tuple Tuple::retrieve(std::string_view id) {
 	std::string_view qry = R"(
 		select
 			space_id,

--- a/src/db/tuples.cpp
+++ b/src/db/tuples.cpp
@@ -72,6 +72,7 @@ std::optional<Tuple> Tuple::lookup(
 			and l_entity_type = $3::text and l_entity_id = $4::text
 			and relation = $5::text
 			and r_entity_type = $6::text and r_entity_id = $7::text
+		;
 	)";
 
 	auto res =

--- a/src/db/tuples.cpp
+++ b/src/db/tuples.cpp
@@ -31,6 +31,25 @@ Tuple::Tuple(const pg::row_t &r) :
 	}),
 	_id(r["_id"].as<std::string>()), _rev(r["_rev"].as<int>()), _rid(r["_rid"].as<rid_t>()) {}
 
+bool Tuple::discard(std::string_view id) {
+	std::string_view qry = R"(
+		delete from tuples
+		where
+			_id = $1::text;
+	)";
+
+	auto res = pg::exec(qry, id);
+	return (res.affected_rows() == 1);
+}
+
+std::optional<Tuple> Tuple::lookup(
+	std::string_view spaceId, std::string_view lPrincipalId, std::string_view rEntityType,
+	std::string_view rEntityId) {
+
+	return lookup(
+		spaceId, "", common::principal_entity_v, lPrincipalId, "", rEntityType, rEntityId);
+}
+
 std::optional<Tuple> Tuple::lookup(
 	std::string_view spaceId, std::string_view strand, std::string_view lEntityType,
 	std::string_view lEntityId, std::string_view relation, std::string_view rEntityType,

--- a/src/db/tuples.h
+++ b/src/db/tuples.h
@@ -62,6 +62,11 @@ public:
 
 	static Tuple retrieve(const std::string &id);
 
+	static std::optional<Tuple> lookup(
+		std::string_view spaceId, std::string_view strand, std::string_view lEntityType,
+		std::string_view lEntityId, std::string_view relation, std::string_view rEntityType,
+		std::string_view rEntityId);
+
 private:
 	void sanitise() noexcept;
 

--- a/src/db/tuples.h
+++ b/src/db/tuples.h
@@ -60,7 +60,7 @@ public:
 
 	void store();
 
-	static Tuple retrieve(const std::string &id);
+	static Tuple retrieve(std::string_view id);
 
 	static std::optional<Tuple> lookup(
 		std::string_view spaceId, std::string_view strand, std::string_view lEntityType,

--- a/src/db/tuples.h
+++ b/src/db/tuples.h
@@ -40,6 +40,7 @@ public:
 	bool operator==(const Tuple &) const noexcept = default;
 
 	const Data::attrs_t &attrs() const noexcept { return _data.attrs; }
+	void                 attrs(std::string &&attrs) noexcept { _data.attrs = std::move(attrs); }
 
 	const std::string &lEntityId() const noexcept { return _data.lEntityId; }
 	const std::string &lEntityType() const noexcept { return _data.lEntityType; }
@@ -60,12 +61,18 @@ public:
 
 	void store();
 
-	static Tuple retrieve(std::string_view id);
+	static bool discard(std::string_view id);
+
+	static std::optional<Tuple> lookup(
+		std::string_view spaceId, std::string_view lPrincipalId, std::string_view rEntityType,
+		std::string_view rEntityId);
 
 	static std::optional<Tuple> lookup(
 		std::string_view spaceId, std::string_view strand, std::string_view lEntityType,
 		std::string_view lEntityId, std::string_view relation, std::string_view rEntityType,
 		std::string_view rEntityId);
+
+	static Tuple retrieve(std::string_view id);
 
 private:
 	void sanitise() noexcept;

--- a/src/db/tuples_test.cpp
+++ b/src/db/tuples_test.cpp
@@ -201,7 +201,7 @@ TEST_F(db_TuplesTest, rev) {
 				$5::text,
 				$6::text, $7::text,
 				$8::text, $9::integer
-			)
+			);
 		)";
 
 		ASSERT_NO_THROW(db::pg::exec(

--- a/src/db/tuples_test.cpp
+++ b/src/db/tuples_test.cpp
@@ -24,6 +24,46 @@ protected:
 	static void TearDownTestSuite() { db::testing::teardown(); }
 };
 
+TEST_F(db_TuplesTest, lookup) {
+	db::Tuple tuple({
+		.lEntityId   = "left",
+		.lEntityType = "db_TuplesTest.lookup",
+		.relation    = "relation",
+		.rEntityId   = "right",
+		.rEntityType = "db_TuplesTest.lookup",
+	});
+	ASSERT_NO_THROW(tuple.store());
+
+	// Success: lookup tuple
+	{
+		auto result = db::Tuple::lookup(
+			tuple.spaceId(),
+			tuple.strand(),
+			tuple.lEntityType(),
+			tuple.lEntityId(),
+			tuple.relation(),
+			tuple.rEntityType(),
+			tuple.rEntityId());
+		ASSERT_TRUE(result);
+
+		EXPECT_EQ(tuple, *result);
+	}
+
+	// Success: lookup non-existent tuple
+	{
+		auto result = db::Tuple::lookup(
+			tuple.spaceId(),
+			tuple.strand(),
+			tuple.lEntityType(),
+			tuple.lEntityId(),
+			"non-existent",
+			tuple.rEntityType(),
+			tuple.rEntityId());
+
+		EXPECT_EQ(std::nullopt, result);
+	}
+}
+
 TEST_F(db_TuplesTest, retrieve) {
 	// Success: retrieve data
 	{

--- a/src/svc/authz.h
+++ b/src/svc/authz.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <google/rpc/status.pb.h>
 
-#include "db/records.h"
+#include "db/tuples.h"
 #include "sentium/api/v1/authz.grpcxx.pb.h"
 
 namespace svc {
@@ -30,10 +30,10 @@ public:
 	google::rpc::Status exception() noexcept;
 
 private:
-	rpcCheck::response_type map(const std::optional<db::Record> &from) const noexcept;
+	rpcCheck::response_type map(const std::optional<db::Tuple> &from) const noexcept;
 
-	db::Record map(const grpcxx::context &ctx, const rpcGrant::request_type &from) const noexcept;
-	rpcGrant::response_type map(const db::Record &from) const noexcept;
+	db::Tuple map(const grpcxx::context &ctx, const rpcGrant::request_type &from) const noexcept;
+	rpcGrant::response_type map(const db::Tuple &from) const noexcept;
 };
 } // namespace authz
 } // namespace svc

--- a/src/svc/authz_test.cpp
+++ b/src/svc/authz_test.cpp
@@ -16,7 +16,7 @@ protected:
 
 		// Clear data
 		db::pg::exec("truncate table principals cascade;");
-		db::pg::exec("truncate table records;");
+		db::pg::exec("truncate table tuples;");
 	}
 
 	static void TearDownTestSuite() { db::testing::teardown(); }
@@ -33,18 +33,18 @@ TEST_F(svc_AuthzTest, Check) {
 
 	// Success: check
 	{
-		db::Record record({
-			.principalId  = principal.id(),
-			.resourceId   = "Check",
-			.resourceType = "svc_AuthzTest",
+		db::Tuple tuple({
+			.lPrincipalId = principal.id(),
+			.rEntityId    = "Check",
+			.rEntityType  = "svc_AuthzTest",
 			.spaceId      = principal.spaceId(),
 		});
-		ASSERT_NO_THROW(record.store());
+		ASSERT_NO_THROW(tuple.store());
 
 		rpcCheck::request_type request;
-		request.set_principal_id(record.principalId());
-		request.set_resource_type(record.resourceType());
-		request.set_resource_id(record.resourceId());
+		request.set_principal_id(*tuple.lPrincipalId());
+		request.set_resource_type(tuple.rEntityType());
+		request.set_resource_id(tuple.rEntityId());
 
 		rpcCheck::result_type result;
 		EXPECT_NO_THROW(result = svc.call<rpcCheck>(ctx, request));
@@ -57,19 +57,19 @@ TEST_F(svc_AuthzTest, Check) {
 
 	// Success: check with `attrs`
 	{
-		db::Record record({
+		db::Tuple tuple({
 			.attrs        = R"({"foo":"bar"})",
-			.principalId  = principal.id(),
-			.resourceId   = "Check-with_attrs",
-			.resourceType = "svc_AuthzTest",
+			.lPrincipalId = principal.id(),
+			.rEntityId    = "Check-with_attrs",
+			.rEntityType  = "svc_AuthzTest",
 			.spaceId      = principal.spaceId(),
 		});
-		ASSERT_NO_THROW(record.store());
+		ASSERT_NO_THROW(tuple.store());
 
 		rpcCheck::request_type request;
-		request.set_principal_id(record.principalId());
-		request.set_resource_type(record.resourceType());
-		request.set_resource_id(record.resourceId());
+		request.set_principal_id(*tuple.lPrincipalId());
+		request.set_resource_type(tuple.rEntityType());
+		request.set_resource_id(tuple.rEntityId());
 
 		rpcCheck::result_type result;
 		EXPECT_NO_THROW(result = svc.call<rpcCheck>(ctx, request));
@@ -80,7 +80,7 @@ TEST_F(svc_AuthzTest, Check) {
 
 		std::string responseAttrs;
 		google::protobuf::util::MessageToJsonString(result.response->attrs(), &responseAttrs);
-		EXPECT_EQ(record.attrs(), responseAttrs);
+		EXPECT_EQ(tuple.attrs(), responseAttrs);
 	}
 
 	// Success: check with space-id
@@ -91,13 +91,13 @@ TEST_F(svc_AuthzTest, Check) {
 		});
 		ASSERT_NO_THROW(principal.store());
 
-		db::Record record({
-			.principalId  = principal.id(),
-			.resourceId   = "Check-with_space_id",
-			.resourceType = "svc_AuthzTest",
+		db::Tuple tuple({
+			.lPrincipalId = principal.id(),
+			.rEntityId    = "Check-with_space_id",
+			.rEntityType  = "svc_AuthzTest",
 			.spaceId      = principal.spaceId(),
 		});
-		ASSERT_NO_THROW(record.store());
+		ASSERT_NO_THROW(tuple.store());
 
 		grpcxx::detail::request r(1);
 		r.header(std::string(svc::common::space_id_v), std::string(principal.spaceId()));
@@ -105,9 +105,9 @@ TEST_F(svc_AuthzTest, Check) {
 		grpcxx::context ctx(r);
 
 		rpcCheck::request_type request;
-		request.set_principal_id(record.principalId());
-		request.set_resource_type(record.resourceType());
-		request.set_resource_id(record.resourceId());
+		request.set_principal_id(*tuple.lPrincipalId());
+		request.set_resource_type(tuple.rEntityType());
+		request.set_resource_id(tuple.rEntityId());
 
 		rpcCheck::result_type result;
 		EXPECT_NO_THROW(result = svc.call<rpcCheck>(ctx, request));
@@ -136,13 +136,13 @@ TEST_F(svc_AuthzTest, Check) {
 
 	// Success: check !ok with space-id
 	{
-		db::Record record({
-			.principalId  = principal.id(),
-			.resourceId   = "Check-space_id_mismatch",
-			.resourceType = "svc_AuthzTest",
+		db::Tuple tuple({
+			.lPrincipalId = principal.id(),
+			.rEntityId    = "Check-space_id_mismatch",
+			.rEntityType  = "svc_AuthzTest",
 			.spaceId      = principal.spaceId(),
 		});
-		ASSERT_NO_THROW(record.store());
+		ASSERT_NO_THROW(tuple.store());
 
 		grpcxx::detail::request r(1);
 		r.header(std::string(svc::common::space_id_v), "invalid");
@@ -150,9 +150,9 @@ TEST_F(svc_AuthzTest, Check) {
 		grpcxx::context ctx(r);
 
 		rpcCheck::request_type request;
-		request.set_principal_id(record.principalId());
-		request.set_resource_type(record.resourceType());
-		request.set_resource_id(record.resourceId());
+		request.set_principal_id(*tuple.lPrincipalId());
+		request.set_resource_type(tuple.rEntityType());
+		request.set_resource_id(tuple.rEntityId());
 
 		rpcCheck::result_type result;
 		EXPECT_NO_THROW(result = svc.call<rpcCheck>(ctx, request));
@@ -214,18 +214,18 @@ TEST_F(svc_AuthzTest, Grant) {
 
 	// Success: upsert
 	{
-		db::Record record({
-			.principalId  = principal.id(),
-			.resourceId   = "Grant-upsert",
-			.resourceType = "svc_AuthzTest",
+		db::Tuple tuple({
+			.lPrincipalId = principal.id(),
+			.rEntityId    = "Grant-upsert",
+			.rEntityType  = "svc_AuthzTest",
 			.spaceId      = principal.spaceId(),
 		});
-		ASSERT_NO_THROW(record.store());
+		ASSERT_NO_THROW(tuple.store());
 
 		rpcGrant::request_type request;
-		request.set_principal_id(record.principalId());
-		request.set_resource_type(record.resourceType());
-		request.set_resource_id(record.resourceId());
+		request.set_principal_id(*tuple.lPrincipalId());
+		request.set_resource_type(tuple.rEntityType());
+		request.set_resource_id(tuple.rEntityId());
 
 		const std::string attrs(R"({"foo":"bar"})");
 		google::protobuf::util::JsonStringToMessage(attrs, request.mutable_attrs());
@@ -236,9 +236,9 @@ TEST_F(svc_AuthzTest, Grant) {
 		EXPECT_EQ(grpcxx::status::code_t::ok, result.status.code());
 		ASSERT_TRUE(result.response);
 
-		auto actual = db::Record::lookup(
-			record.spaceId(), record.principalId(), record.resourceType(), record.resourceId());
-		EXPECT_EQ(record.rev() + 1, actual->rev());
+		auto actual = db::Tuple::lookup(
+			tuple.spaceId(), *tuple.lPrincipalId(), tuple.rEntityType(), tuple.rEntityId());
+		EXPECT_EQ(tuple.rev() + 1, actual->rev());
 		EXPECT_EQ(R"({"foo": "bar"})", actual->attrs());
 	}
 
@@ -299,18 +299,18 @@ TEST_F(svc_AuthzTest, Revoke) {
 
 	// Success: revoke
 	{
-		db::Record record({
-			.principalId  = principal.id(),
-			.resourceId   = "Revoke",
-			.resourceType = "svc_AuthzTest",
+		db::Tuple tuple({
+			.lPrincipalId = principal.id(),
+			.rEntityId    = "Revoke",
+			.rEntityType  = "svc_AuthzTest",
 			.spaceId      = principal.spaceId(),
 		});
-		ASSERT_NO_THROW(record.store());
+		ASSERT_NO_THROW(tuple.store());
 
 		rpcRevoke::request_type request;
-		request.set_principal_id(record.principalId());
-		request.set_resource_type(record.resourceType());
-		request.set_resource_id(record.resourceId());
+		request.set_principal_id(*tuple.lPrincipalId());
+		request.set_resource_type(tuple.rEntityType());
+		request.set_resource_id(tuple.rEntityId());
 
 		rpcRevoke::result_type result;
 		EXPECT_NO_THROW(result = svc.call<rpcRevoke>(ctx, request));
@@ -318,19 +318,19 @@ TEST_F(svc_AuthzTest, Revoke) {
 		EXPECT_EQ(grpcxx::status::code_t::ok, result.status.code());
 		ASSERT_TRUE(result.response);
 
-		EXPECT_FALSE(db::Record::lookup(
-			record.spaceId(), record.principalId(), record.resourceType(), record.resourceId()));
+		EXPECT_FALSE(db::Tuple::lookup(
+			tuple.spaceId(), *tuple.lPrincipalId(), tuple.rEntityType(), tuple.rEntityId()));
 	}
 
 	// Success: invalid space-id
 	{
-		db::Record record({
-			.principalId  = principal.id(),
-			.resourceId   = "Revoke-invalid_space_id",
-			.resourceType = "svc_AuthzTest",
+		db::Tuple tuple({
+			.lPrincipalId = principal.id(),
+			.rEntityId    = "Revoke-invalid_space_id",
+			.rEntityType  = "svc_AuthzTest",
 			.spaceId      = principal.spaceId(),
 		});
-		ASSERT_NO_THROW(record.store());
+		ASSERT_NO_THROW(tuple.store());
 
 		grpcxx::detail::request r(1);
 		r.header(std::string(svc::common::space_id_v), "invalid");
@@ -338,9 +338,9 @@ TEST_F(svc_AuthzTest, Revoke) {
 		grpcxx::context ctx(r);
 
 		rpcRevoke::request_type request;
-		request.set_principal_id(record.principalId());
-		request.set_resource_type(record.resourceType());
-		request.set_resource_id(record.resourceId());
+		request.set_principal_id(*tuple.lPrincipalId());
+		request.set_resource_type(tuple.rEntityType());
+		request.set_resource_id(tuple.rEntityId());
 
 		rpcRevoke::result_type result;
 		EXPECT_NO_THROW(result = svc.call<rpcRevoke>(ctx, request));
@@ -348,7 +348,7 @@ TEST_F(svc_AuthzTest, Revoke) {
 		EXPECT_EQ(grpcxx::status::code_t::ok, result.status.code());
 		ASSERT_TRUE(result.response);
 
-		EXPECT_TRUE(db::Record::lookup(
-			record.spaceId(), record.principalId(), record.resourceType(), record.resourceId()));
+		EXPECT_TRUE(db::Tuple::lookup(
+			tuple.spaceId(), *tuple.lPrincipalId(), tuple.rEntityType(), tuple.rEntityId()));
 	}
 }


### PR DESCRIPTION
ReBAC implementation is based on relation tuples which can be used for storing authorisation records.

This change is to update all Authz gRPC service endpoints to use `tuples` instead of `records`. Records will be dropped after moving all functionality to Tuples.