### PR TITLE
Tidy-up Authz gRPC service

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ Listening on [127.0.0.1:8080] ...
   -plaintext \
   -d '{
     "principal_id": "cn7qtdu56a1cqrj8kur0",
-    "resource_type": "documents",
-    "resource_id": "65bd28aaa076ee8c8463cff8"
+    "entity_type": "documents",
+    "entity_id": "65bd28aaa076ee8c8463cff8"
   }' \
   localhost:8080 sentium.api.v1.Authz/Grant
 
@@ -134,8 +134,8 @@ Listening on [127.0.0.1:8080] ...
   -plaintext \
   -d '{
     "principal_id": "cn7qtdu56a1cqrj8kur0",
-    "resource_type": "documents",
-    "resource_id": "65bd28aaa076ee8c8463cff8"
+    "entity_type": "documents",
+    "entity_id": "65bd28aaa076ee8c8463cff8"
   }' \
   localhost:8080 sentium.api.v1.Authz/Check
 

--- a/proto/sentium/api/v1/authz.proto
+++ b/proto/sentium/api/v1/authz.proto
@@ -29,9 +29,9 @@ service Authz {
 }
 
 message AuthzCheckRequest {
-	string principal_id  = 1;
-	string resource_id   = 3;
-	string resource_type = 2;
+	string principal_id = 1;
+	string entity_id    = 3;
+	string entity_type  = 2;
 }
 
 message AuthzCheckResponse {
@@ -41,9 +41,9 @@ message AuthzCheckResponse {
 }
 
 message AuthzGrantRequest {
-	string principal_id  = 1;
-	string resource_id   = 3;
-	string resource_type = 2;
+	string principal_id = 1;
+	string entity_id    = 3;
+	string entity_type  = 2;
 
 	optional google.protobuf.Struct attrs = 4;
 }
@@ -51,9 +51,9 @@ message AuthzGrantRequest {
 message AuthzGrantResponse {}
 
 message AuthzRevokeRequest {
-	string principal_id  = 1;
-	string resource_id   = 3;
-	string resource_type = 2;
+	string principal_id = 1;
+	string entity_id    = 3;
+	string entity_type  = 2;
 }
 
 message AuthzRevokeResponse {}

--- a/src/svc/authz.cpp
+++ b/src/svc/authz.cpp
@@ -13,9 +13,7 @@ template <>
 rpcCheck::result_type Impl::call<rpcCheck>(
 	grpcxx::context &ctx, const rpcCheck::request_type &req) {
 	auto r = db::Tuple::lookup(
-		ctx.meta(common::space_id_v),
-		{req.principal_id()},
-		{req.resource_type(), req.resource_id()});
+		ctx.meta(common::space_id_v), {req.principal_id()}, {req.entity_type(), req.entity_id()});
 	return {grpcxx::status::code_t::ok, map(r)};
 }
 
@@ -26,7 +24,7 @@ rpcGrant::result_type Impl::call<rpcGrant>(
 	if (auto r = db::Tuple::lookup(
 			ctx.meta(common::space_id_v),
 			{req.principal_id()},
-			{req.resource_type(), req.resource_id()});
+			{req.entity_type(), req.entity_id()});
 		r) {
 		if (req.has_attrs()) {
 			std::string attrs;
@@ -51,7 +49,7 @@ rpcRevoke::result_type Impl::call<rpcRevoke>(
 	if (auto r = db::Tuple::lookup(
 			ctx.meta(common::space_id_v),
 			{req.principal_id()},
-			{req.resource_type(), req.resource_id()});
+			{req.entity_type(), req.entity_id()});
 		r) {
 		db::Tuple::discard(r->id());
 	}
@@ -85,8 +83,8 @@ google::rpc::Status Impl::exception() noexcept {
 db::Tuple Impl::map(const grpcxx::context &ctx, const rpcGrant::request_type &from) const noexcept {
 	db::Tuple to({
 		.lPrincipalId = from.principal_id(),
-		.rEntityId    = from.resource_id(),
-		.rEntityType  = from.resource_type(),
+		.rEntityId    = from.entity_id(),
+		.rEntityType  = from.entity_type(),
 		.spaceId      = std::string(ctx.meta(common::space_id_v)),
 	});
 

--- a/src/svc/authz_test.cpp
+++ b/src/svc/authz_test.cpp
@@ -43,8 +43,8 @@ TEST_F(svc_AuthzTest, Check) {
 
 		rpcCheck::request_type request;
 		request.set_principal_id(*tuple.lPrincipalId());
-		request.set_resource_type(tuple.rEntityType());
-		request.set_resource_id(tuple.rEntityId());
+		request.set_entity_type(tuple.rEntityType());
+		request.set_entity_id(tuple.rEntityId());
 
 		rpcCheck::result_type result;
 		EXPECT_NO_THROW(result = svc.call<rpcCheck>(ctx, request));
@@ -68,8 +68,8 @@ TEST_F(svc_AuthzTest, Check) {
 
 		rpcCheck::request_type request;
 		request.set_principal_id(*tuple.lPrincipalId());
-		request.set_resource_type(tuple.rEntityType());
-		request.set_resource_id(tuple.rEntityId());
+		request.set_entity_type(tuple.rEntityType());
+		request.set_entity_id(tuple.rEntityId());
 
 		rpcCheck::result_type result;
 		EXPECT_NO_THROW(result = svc.call<rpcCheck>(ctx, request));
@@ -106,8 +106,8 @@ TEST_F(svc_AuthzTest, Check) {
 
 		rpcCheck::request_type request;
 		request.set_principal_id(*tuple.lPrincipalId());
-		request.set_resource_type(tuple.rEntityType());
-		request.set_resource_id(tuple.rEntityId());
+		request.set_entity_type(tuple.rEntityType());
+		request.set_entity_id(tuple.rEntityId());
 
 		rpcCheck::result_type result;
 		EXPECT_NO_THROW(result = svc.call<rpcCheck>(ctx, request));
@@ -122,8 +122,8 @@ TEST_F(svc_AuthzTest, Check) {
 	{
 		rpcCheck::request_type request;
 		request.set_principal_id("non-existent");
-		request.set_resource_type("svc_AuthzTest");
-		request.set_resource_id("Check-non_existent");
+		request.set_entity_type("svc_AuthzTest");
+		request.set_entity_id("Check-non_existent");
 
 		rpcCheck::result_type result;
 		EXPECT_NO_THROW(result = svc.call<rpcCheck>(ctx, request));
@@ -151,8 +151,8 @@ TEST_F(svc_AuthzTest, Check) {
 
 		rpcCheck::request_type request;
 		request.set_principal_id(*tuple.lPrincipalId());
-		request.set_resource_type(tuple.rEntityType());
-		request.set_resource_id(tuple.rEntityId());
+		request.set_entity_type(tuple.rEntityType());
+		request.set_entity_id(tuple.rEntityId());
 
 		rpcCheck::result_type result;
 		EXPECT_NO_THROW(result = svc.call<rpcCheck>(ctx, request));
@@ -177,8 +177,8 @@ TEST_F(svc_AuthzTest, Grant) {
 	{
 		rpcGrant::request_type request;
 		request.set_principal_id(principal.id());
-		request.set_resource_type("svc_AuthzTest");
-		request.set_resource_id("Grant");
+		request.set_entity_type("svc_AuthzTest");
+		request.set_entity_id("Grant");
 
 		rpcGrant::result_type result;
 		EXPECT_NO_THROW(result = svc.call<rpcGrant>(ctx, request));
@@ -202,8 +202,8 @@ TEST_F(svc_AuthzTest, Grant) {
 
 		rpcGrant::request_type request;
 		request.set_principal_id(principal.id());
-		request.set_resource_type("svc_AuthzTest");
-		request.set_resource_id("Grant-with_space_id");
+		request.set_entity_type("svc_AuthzTest");
+		request.set_entity_id("Grant-with_space_id");
 
 		rpcGrant::result_type result;
 		EXPECT_NO_THROW(result = svc.call<rpcGrant>(ctx, request));
@@ -224,8 +224,8 @@ TEST_F(svc_AuthzTest, Grant) {
 
 		rpcGrant::request_type request;
 		request.set_principal_id(*tuple.lPrincipalId());
-		request.set_resource_type(tuple.rEntityType());
-		request.set_resource_id(tuple.rEntityId());
+		request.set_entity_type(tuple.rEntityType());
+		request.set_entity_id(tuple.rEntityId());
 
 		const std::string attrs(R"({"foo":"bar"})");
 		google::protobuf::util::JsonStringToMessage(attrs, request.mutable_attrs());
@@ -258,8 +258,8 @@ TEST_F(svc_AuthzTest, Grant) {
 	{
 		rpcGrant::request_type request;
 		request.set_principal_id("invalid");
-		request.set_resource_type("svc_AuthzTest");
-		request.set_resource_id("Grant-invalid_principal_id");
+		request.set_entity_type("svc_AuthzTest");
+		request.set_entity_id("Grant-invalid_principal_id");
 
 		rpcGrant::result_type result;
 		EXPECT_NO_THROW(result = svc.call<rpcGrant>(ctx, request));
@@ -277,8 +277,8 @@ TEST_F(svc_AuthzTest, Grant) {
 
 		rpcGrant::request_type request;
 		request.set_principal_id(principal.id());
-		request.set_resource_type("svc_AuthzTest");
-		request.set_resource_id("Grant-invalid_space_id");
+		request.set_entity_type("svc_AuthzTest");
+		request.set_entity_id("Grant-invalid_space_id");
 
 		rpcGrant::result_type result;
 		EXPECT_NO_THROW(result = svc.call<rpcGrant>(ctx, request));
@@ -309,8 +309,8 @@ TEST_F(svc_AuthzTest, Revoke) {
 
 		rpcRevoke::request_type request;
 		request.set_principal_id(*tuple.lPrincipalId());
-		request.set_resource_type(tuple.rEntityType());
-		request.set_resource_id(tuple.rEntityId());
+		request.set_entity_type(tuple.rEntityType());
+		request.set_entity_id(tuple.rEntityId());
 
 		rpcRevoke::result_type result;
 		EXPECT_NO_THROW(result = svc.call<rpcRevoke>(ctx, request));
@@ -339,8 +339,8 @@ TEST_F(svc_AuthzTest, Revoke) {
 
 		rpcRevoke::request_type request;
 		request.set_principal_id(*tuple.lPrincipalId());
-		request.set_resource_type(tuple.rEntityType());
-		request.set_resource_id(tuple.rEntityId());
+		request.set_entity_type(tuple.rEntityType());
+		request.set_entity_id(tuple.rEntityId());
 
 		rpcRevoke::result_type result;
 		EXPECT_NO_THROW(result = svc.call<rpcRevoke>(ctx, request));


### PR DESCRIPTION
Favour _entity_ over _resource_ for protobuf field names. 

💡 Since this is just a field name change (and not type or number change) this is a non-breaking change.