### PR TITLE
ReBAC: Optimise when creating relations

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -36,8 +36,12 @@ create table if not exists tuples (
 	r_principal_id  text,
 
 	_id   text    not null,
-	_rid  text,  -- self reference for computed tuples
 	_rev  integer not null,
+
+	-- Self references for computed tuples
+	--
+	_rid_l  text,
+	_rid_r  text, 
 
 	constraint "tuples.pkey" primary key (_id),
 	constraint "tuples.unique" unique (
@@ -47,7 +51,11 @@ create table if not exists tuples (
 		r_entity_type, r_entity_id,
 		strand),
 
-	constraint "tuples.fkey-_rid" foreign key (_rid)
+	constraint "tuples.fkey-_rid_l" foreign key (_rid_l)
+		references tuples(_id)
+		on delete cascade,
+
+	constraint "tuples.fkey-_rid_r" foreign key (_rid_r)
 		references tuples(_id)
 		on delete cascade,
 

--- a/proto/sentium/api/v1/relations.proto
+++ b/proto/sentium/api/v1/relations.proto
@@ -113,6 +113,8 @@ message RelationsCreateRequest {
 message RelationsCreateResponse {
 	Tuple  tuple = 1;
 	uint32 cost  = 2;
+
+	repeated Tuple computed_tuples = 3;
 }
 
 message RelationsDeleteRequest {

--- a/proto/sentium/api/v1/relations.proto
+++ b/proto/sentium/api/v1/relations.proto
@@ -64,7 +64,8 @@ message Tuple {
 	optional string strand                = 8;
 	optional google.protobuf.Struct attrs = 9;
 
-	optional string ref_id = 10;
+	optional string ref_id_left  = 10;
+	optional string ref_id_right = 11;
 }
 
 message RelationsCheckRequest {

--- a/src/db/tuples.cpp
+++ b/src/db/tuples.cpp
@@ -34,6 +34,19 @@ Tuple::Tuple(const pg::row_t &r) :
 	_id(r["_id"].as<std::string>()), _rev(r["_rev"].as<int>()), _ridL(r["_rid_l"].as<rid_t>()),
 	_ridR(r["_rid_r"].as<rid_t>()) {}
 
+Tuple::Tuple(const Tuple &left, const Tuple &right) noexcept :
+	_data({
+		.lEntityId    = left.lEntityId(),
+		.lEntityType  = left.lEntityType(),
+		.lPrincipalId = left.lPrincipalId(),
+		.relation     = right.relation(),
+		.rEntityId    = right.rEntityId(),
+		.rEntityType  = right.rEntityType(),
+		.rPrincipalId = right.rPrincipalId(),
+		.spaceId      = left.spaceId(),
+	}),
+	_id(xid::next()), _rev(0), _ridL(left.id()), _ridR(right.id()) {}
+
 bool Tuple::discard(std::string_view id) {
 	std::string_view qry = R"(
 		delete from tuples

--- a/src/db/tuples.cpp
+++ b/src/db/tuples.cpp
@@ -114,7 +114,7 @@ void Tuple::store() {
 			$8::jsonb,
 			$9::text, $10::text,
 			$11::text, $12::integer,
-			$13::text, $14::text 
+			$13::text, $14::text
 		)
 		on conflict (_id)
 		do update

--- a/src/db/tuples.cpp
+++ b/src/db/tuples.cpp
@@ -8,13 +8,12 @@
 #include "common.h"
 
 namespace db {
-Tuple::Tuple(const Tuple::Data &data) noexcept :
-	_data(data), _id(xid::next()), _rev(0), _ridL(), _ridR() {
+Tuple::Tuple(const Tuple::Data &data) noexcept : _data(data), _id(), _rev(0), _ridL(), _ridR() {
 	sanitise();
 }
 
 Tuple::Tuple(Tuple::Data &&data) noexcept :
-	_data(std::move(data)), _id(xid::next()), _rev(0), _ridL(), _ridR() {
+	_data(std::move(data)), _id(), _rev(0), _ridL(), _ridR() {
 	sanitise();
 }
 
@@ -45,7 +44,7 @@ Tuple::Tuple(const Tuple &left, const Tuple &right) noexcept :
 		.rPrincipalId = right.rPrincipalId(),
 		.spaceId      = left.spaceId(),
 	}),
-	_id(xid::next()), _rev(0), _ridL(left.id()), _ridR(right.id()) {}
+	_id(), _rev(0), _ridL(left.id()), _ridR(right.id()) {}
 
 bool Tuple::discard(std::string_view id) {
 	std::string_view qry = R"(
@@ -107,6 +106,10 @@ void Tuple::sanitise() noexcept {
 }
 
 void Tuple::store() {
+	if (_id.empty()) {
+		_id = xid::next();
+	}
+
 	std::string_view qry = R"(
 		insert into tuples as t (
 			space_id,

--- a/src/db/tuples.h
+++ b/src/db/tuples.h
@@ -52,6 +52,8 @@ public:
 
 	Tuple(const pg::row_t &r);
 
+	Tuple(const Tuple &left, const Tuple &right) noexcept;
+
 	bool operator==(const Tuple &) const noexcept = default;
 
 	const Data::attrs_t &attrs() const noexcept { return _data.attrs; }

--- a/src/db/tuples.h
+++ b/src/db/tuples.h
@@ -82,7 +82,8 @@ public:
 
 	const std::string &id() const noexcept { return _id; }
 	const int         &rev() const noexcept { return _rev; }
-	const rid_t       &rid() const noexcept { return _rid; }
+	const rid_t       &ridL() const noexcept { return _ridL; }
+	const rid_t       &ridR() const noexcept { return _ridR; }
 
 	void store();
 
@@ -100,7 +101,8 @@ private:
 	Data        _data;
 	std::string _id;
 	int         _rev;
-	rid_t       _rid;
+	rid_t       _ridL;
+	rid_t       _ridR;
 };
 
 using Tuples = std::vector<Tuple>;

--- a/src/db/tuples_test.cpp
+++ b/src/db/tuples_test.cpp
@@ -512,36 +512,15 @@ TEST_F(db_TuplesTest, rev) {
 			.rEntityId   = "right",
 			.rEntityType = "db_TuplesTest.rev-mismatch",
 		});
+		ASSERT_NO_THROW(tuple.store());
 
 		std::string_view qry = R"(
-			insert into tuples as t (
-				space_id,
-				strand,
-				l_entity_type, l_entity_id,
-				relation,
-				r_entity_type, r_entity_id,
-				_id, _rev
-			) values (
-				$1::text,
-				$2::text,
-				$3::text, $4::text,
-				$5::text,
-				$6::text, $7::text,
-				$8::text, $9::integer
-			);
+			update tuples
+			set
+				_rev = $2::integer
+			where _id = $1::text;
 		)";
-
-		ASSERT_NO_THROW(db::pg::exec(
-			qry,
-			tuple.spaceId(),
-			tuple.strand(),
-			tuple.lEntityType(),
-			tuple.lEntityId(),
-			tuple.relation(),
-			tuple.rEntityType(),
-			tuple.rEntityId(),
-			tuple.id(),
-			tuple.rev() + 1));
+		ASSERT_NO_THROW(db::pg::exec(qry, tuple.id(), tuple.rev() + 1));
 
 		EXPECT_THROW(tuple.store(), err::DbRevisionMismatch);
 	}

--- a/src/db/tuples_test.cpp
+++ b/src/db/tuples_test.cpp
@@ -24,6 +24,48 @@ protected:
 	static void TearDownTestSuite() { db::testing::teardown(); }
 };
 
+TEST_F(db_TuplesTest, constructor) {
+	// Success: join tuples
+	{
+		db::Tuple left({
+			.lEntityId   = "(left)left",
+			.lEntityType = "(left)db_TuplesTest.constructor",
+			.relation    = "(left)relation",
+			.rEntityId   = "(left)right",
+			.rEntityType = "(left)db_TuplesTest.constructor",
+			.spaceId     = "space-id",
+		});
+		ASSERT_NO_THROW(left.store());
+
+		db::Tuple right({
+			.lEntityId   = "(right)left",
+			.lEntityType = "(right)db_TuplesTest.constructor",
+			.relation    = "(right)relation",
+			.rEntityId   = "(right)right",
+			.rEntityType = "(right)db_TuplesTest.constructor",
+			.spaceId     = "space-id",
+		});
+		ASSERT_NO_THROW(right.store());
+
+		db::Tuple joined(left, right);
+		ASSERT_NO_THROW(joined.store());
+
+		EXPECT_EQ(left.lEntityId(), joined.lEntityId());
+		EXPECT_EQ(left.lEntityType(), joined.lEntityType());
+		EXPECT_EQ(right.relation(), joined.relation());
+		EXPECT_EQ(right.rEntityId(), joined.rEntityId());
+		EXPECT_EQ(right.rEntityType(), joined.rEntityType());
+		EXPECT_EQ(left.spaceId(), joined.spaceId());
+		EXPECT_TRUE(joined.strand().empty());
+		EXPECT_EQ(left.id(), joined.ridL());
+		EXPECT_EQ(right.id(), joined.ridR());
+
+		EXPECT_FALSE(joined.attrs());
+		EXPECT_FALSE(joined.lPrincipalId());
+		EXPECT_FALSE(joined.rPrincipalId());
+	}
+}
+
 TEST_F(db_TuplesTest, discard) {
 	db::Tuple tuple({
 		.lEntityId   = "left",

--- a/src/db/tuples_test.cpp
+++ b/src/db/tuples_test.cpp
@@ -418,7 +418,8 @@ TEST_F(db_TuplesTest, retrieve) {
 			1729));
 
 		auto tuple = db::Tuple::retrieve("_id:db_TuplesTest.retrieve");
-		EXPECT_FALSE(tuple.rid());
+		EXPECT_FALSE(tuple.ridL());
+		EXPECT_FALSE(tuple.ridR());
 		EXPECT_EQ(1729, tuple.rev());
 
 		EXPECT_EQ("db_TuplesTest.retrieve", tuple.lEntityType());
@@ -544,7 +545,8 @@ TEST_F(db_TuplesTest, store) {
 				r_entity_type, r_entity_id,
 				attrs,
 				l_principal_id, r_principal_id,
-				_id, _rid, _rev
+				_id, _rev,
+				_rid_l, _rid_r
 			from tuples
 			where _id = $1::text;
 		)";
@@ -564,8 +566,9 @@ TEST_F(db_TuplesTest, store) {
 			 lPrincipalId,
 			 rPrincipalId,
 			 _id,
-			 _rid,
-			 _rev] =
+			 _rev,
+			 _ridL,
+			 _ridR] =
 				res[0]
 					.as<std::string,
 						std::string,
@@ -578,8 +581,9 @@ TEST_F(db_TuplesTest, store) {
 						db::Tuple::Data::pid_t,
 						db::Tuple::Data::pid_t,
 						std::string,
+						int,
 						db::Tuple::rid_t,
-						int>();
+						db::Tuple::rid_t>();
 
 		EXPECT_EQ(tuple.spaceId(), spaceId);
 		EXPECT_EQ(tuple.strand(), strand);
@@ -593,7 +597,8 @@ TEST_F(db_TuplesTest, store) {
 		EXPECT_EQ(tuple.rPrincipalId(), rPrincipalId);
 		EXPECT_EQ(tuple.id(), _id);
 		EXPECT_EQ(tuple.rev(), _rev);
-		EXPECT_EQ(tuple.rid(), _rid);
+		EXPECT_EQ(tuple.ridL(), _ridL);
+		EXPECT_EQ(tuple.ridR(), _ridR);
 	}
 
 	// Error: invalid `attrs`

--- a/src/svc/common.h
+++ b/src/svc/common.h
@@ -4,6 +4,8 @@
 
 namespace svc {
 namespace common {
+static constexpr std::uint16_t cost_limit_v = 1000;
+
 static constexpr std::uint16_t pagination_limit_v = 30;
 
 static constexpr std::string_view space_id_v = "space-id";

--- a/src/svc/relations.cpp
+++ b/src/svc/relations.cpp
@@ -259,8 +259,12 @@ void Impl::map(const db::Tuple &from, sentium::api::v1::Tuple *to) const noexcep
 		google::protobuf::util::JsonStringToMessage(*from.attrs(), to->mutable_attrs());
 	}
 
-	if (from.rid()) {
-		to->set_ref_id(*from.rid());
+	if (from.ridL()) {
+		to->set_ref_id_left(*from.ridL());
+	}
+
+	if (from.ridR()) {
+		to->set_ref_id_right(*from.ridR());
 	}
 }
 

--- a/src/svc/relations_test.cpp
+++ b/src/svc/relations_test.cpp
@@ -71,7 +71,8 @@ TEST_F(svc_RelationsTest, Check) {
 		EXPECT_EQ(tuple.rEntityType(), actual.right_entity().type());
 		EXPECT_EQ(tuple.strand(), actual.strand());
 		EXPECT_FALSE(actual.has_attrs());
-		EXPECT_FALSE(actual.has_ref_id());
+		EXPECT_FALSE(actual.has_ref_id_left());
+		EXPECT_FALSE(actual.has_ref_id_right());
 	}
 
 	// Success: found with principals
@@ -113,7 +114,8 @@ TEST_F(svc_RelationsTest, Check) {
 		EXPECT_EQ(*tuple.rPrincipalId(), actual.right_principal_id());
 		EXPECT_FALSE(actual.has_strand());
 		EXPECT_FALSE(actual.has_attrs());
-		EXPECT_FALSE(actual.has_ref_id());
+		EXPECT_FALSE(actual.has_ref_id_left());
+		EXPECT_FALSE(actual.has_ref_id_right());
 	}
 
 	// Success: not found (space-id mismatch)
@@ -203,7 +205,8 @@ TEST_F(svc_RelationsTest, Create) {
 		google::protobuf::util::MessageToJsonString(actual.attrs(), &responseAttrs);
 		EXPECT_EQ(attrs, responseAttrs);
 
-		EXPECT_FALSE(actual.has_ref_id());
+		EXPECT_FALSE(actual.has_ref_id_left());
+		EXPECT_FALSE(actual.has_ref_id_right());
 	}
 
 	// Success: create relation with principals
@@ -235,7 +238,8 @@ TEST_F(svc_RelationsTest, Create) {
 
 		EXPECT_FALSE(actual.has_strand());
 		EXPECT_FALSE(actual.has_attrs());
-		EXPECT_FALSE(actual.has_ref_id());
+		EXPECT_FALSE(actual.has_ref_id_left());
+		EXPECT_FALSE(actual.has_ref_id_right());
 	}
 
 	// Success: create relation with space-id
@@ -280,7 +284,8 @@ TEST_F(svc_RelationsTest, Create) {
 
 		EXPECT_FALSE(actual.has_strand());
 		EXPECT_FALSE(actual.has_attrs());
-		EXPECT_FALSE(actual.has_ref_id());
+		EXPECT_FALSE(actual.has_ref_id_left());
+		EXPECT_FALSE(actual.has_ref_id_right());
 	}
 
 	// Error: invalid entity
@@ -475,7 +480,8 @@ TEST_F(svc_RelationsTest, ListLeft) {
 		EXPECT_EQ(principal.id(), actual[0].right_principal_id());
 		EXPECT_FALSE(actual[0].has_strand());
 		EXPECT_FALSE(actual[0].has_attrs());
-		EXPECT_FALSE(actual[0].has_ref_id());
+		EXPECT_FALSE(actual[0].has_ref_id_left());
+		EXPECT_FALSE(actual[0].has_ref_id_right());
 	}
 
 	// Success: list left with relation
@@ -700,7 +706,8 @@ TEST_F(svc_RelationsTest, ListRight) {
 		EXPECT_EQ(tuple.rEntityType(), actual[0].right_entity().type());
 		EXPECT_FALSE(actual[0].has_strand());
 		EXPECT_FALSE(actual[0].has_attrs());
-		EXPECT_FALSE(actual[0].has_ref_id());
+		EXPECT_FALSE(actual[0].has_ref_id_left());
+		EXPECT_FALSE(actual[0].has_ref_id_right());
 	}
 
 	// Success: list right with relation


### PR DESCRIPTION
This change utilises the `optimise` flag to compute and store derived relations when creating a new relation. The `cost_limit` can be used to avoid expensive DB operations during an insert.

💡 If the cost of storing derived tuples is larger than the `cost_limit`, the response will have a `cost_limit + 1` as the `cost` and any pending computed tuples with empty ids in `computed_tuples`.