### PR TITLE
ReBAC: `set` strategy for checking relations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ endif
 .PHONY: $(binary) clean lint lint\:ci lint\:fix
 .SILENT: coverage lint lint\:fix
 
+%:
+	@:
+
 all: $(binary)
 
 $(binary): $(buildfile)
@@ -40,7 +43,7 @@ $(buildfile):
 	cmake -B $(builddir) -G Ninja
 
 bench: $(binary)
-	$(benchbin)
+	$(benchbin) $(filter-out $@,$(MAKECMDGOALS)) $(MAKEFLAGS)
 
 clean:
 	cmake --build $(builddir) --target clean

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(${PROJECT_NAME}_bench
+	algorithms_test.cpp
 	main.cpp
 	relations_test.cpp
 )

--- a/bench/algorithms_test.cpp
+++ b/bench/algorithms_test.cpp
@@ -1,0 +1,86 @@
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include <benchmark/benchmark.h>
+#include <xid/xid.h>
+
+BENCHMARK([](benchmark::State &st) {
+	std::vector<std::string> left;
+	std::vector<std::string> right;
+
+	left.reserve(st.range(0));
+	right.reserve(st.range(0));
+
+	for (int n = st.range(0); n > 0; n--) {
+		left.emplace_back(xid::next());
+		right.emplace_back(xid::next());
+	}
+
+	for (auto _ : st) {
+		for (const auto &s : left) {
+			if (std::binary_search(right.begin(), right.end(), s)) {
+				break;
+			}
+		}
+	}
+})
+	->Name("bm_binary_intersection")
+	->Range(8, 8 << 10);
+
+BENCHMARK([](benchmark::State &st) {
+	std::vector<std::string> left;
+	std::vector<std::string> right;
+
+	left.reserve(st.range(0));
+	right.reserve(st.range(0));
+
+	std::vector<std::string> intersection;
+
+	for (int n = st.range(0); n > 0; n--) {
+		left.emplace_back(xid::next());
+		right.emplace_back(xid::next());
+	}
+
+	for (auto _ : st) {
+		intersection.clear();
+		std::set_intersection(
+			left.begin(), left.end(), right.begin(), right.end(), std::back_inserter(intersection));
+	}
+})
+	->Name("bm_set_intersection")
+	->Range(8, 8 << 10);
+
+BENCHMARK([](benchmark::State &st) {
+	std::vector<std::string> left;
+	std::vector<std::string> right;
+
+	left.reserve(st.range(0));
+	right.reserve(st.range(0));
+
+	for (int n = st.range(0); n > 0; n--) {
+		left.emplace_back(xid::next());
+		right.emplace_back(xid::next());
+	}
+
+	for (auto _ : st) {
+		auto i = left.cbegin();
+		auto j = right.cbegin();
+
+		while (i != left.cend() && j != right.cend()) {
+			auto r = i->compare(*j);
+
+			if (r == 0) {
+				break;
+			}
+
+			if (r < 0) {
+				i++;
+			} else {
+				j++;
+			}
+		}
+	}
+})
+	->Name("bm_spot_intersection")
+	->Range(8, 8 << 10);

--- a/proto/sentium/api/v1/relations.proto
+++ b/proto/sentium/api/v1/relations.proto
@@ -80,6 +80,17 @@ message RelationsCheckRequest {
 		Entity right_entity       = 3;
 		string right_principal_id = 4;
 	}
+
+	// Lookup strategy to use. Defaults to `2` (direct).
+	//
+	// Strategies:
+	//   2 (direct) - Only check if there's a direct relation exists between the entities.
+	//   8 (set)    - Check if there's a direct relation exists between the entities and if not, use
+	//                a set intersection algorithm to derive a relation between the entities.
+	optional uint32 strategy = 6;
+
+	// Limits the lookup cost. The value must be within `1` and `65535`. Defaults to `1000`.
+	optional uint32 cost_limit = 7;
 }
 
 message RelationsCheckResponse {

--- a/proto/sentium/api/v1/relations.proto
+++ b/proto/sentium/api/v1/relations.proto
@@ -94,9 +94,15 @@ message RelationsCheckRequest {
 }
 
 message RelationsCheckResponse {
-	bool  found = 1;
-	int32 cost  = 2;
+	// Indicates if a relation exists or could be derived using the lookup strategy.
+	bool found = 1;
 
+	// Cost of lookups. A negative cost indicates the lookup cost exceeded the limit and the process
+	// _may_ have been abandoned without computing all possible derivations.
+	int32 cost = 2;
+
+	// Tuple containing relation data that matched the query. An empty tuple `id` indicates a computed
+	// tuple which isn't stored.
 	optional Tuple tuple = 3;
 }
 

--- a/src/db/tuples.h
+++ b/src/db/tuples.h
@@ -80,7 +80,9 @@ public:
 	}
 
 	const std::string &spaceId() const noexcept { return _data.spaceId; }
+
 	const std::string &strand() const noexcept { return _data.strand; }
+	void               strand(const std::string &strand) noexcept { _data.strand = strand; }
 
 	const std::string &id() const noexcept { return _id; }
 	const int         &rev() const noexcept { return _rev; }

--- a/src/err/errors.h
+++ b/src/err/errors.h
@@ -24,4 +24,6 @@ using DbTuplesInvalidListArgs =
 
 using RpcPrincipalsAlreadyExists = basic_error<"sentium:2.1.1.409", "Principal already exists">;
 using RpcPrincipalsNotFound      = basic_error<"sentium:2.1.2.404", "Principal not found">;
+
+using RpcRelationsInvalidStrategy = basic_error<"sentium:2.2.1.400", "Invalid relations strategy">;
 } // namespace err

--- a/src/svc/relations.cpp
+++ b/src/svc/relations.cpp
@@ -95,6 +95,10 @@ rpcCheck::result_type Impl::call<rpcCheck>(
 		}
 	}
 
+	if (cost >= limit) {
+		cost *= -1;
+	}
+
 	response.set_cost(cost);
 
 	return {grpcxx::status::code_t::ok, response};

--- a/src/svc/relations.cpp
+++ b/src/svc/relations.cpp
@@ -26,7 +26,6 @@ rpcCheck::result_type Impl::call<rpcCheck>(
 			break;
 		default:
 			throw err::RpcRelationsInvalidStrategy();
-			break;
 		}
 	}
 
@@ -119,7 +118,6 @@ rpcCreate::result_type Impl::call<rpcCreate>(
 			break;
 		default:
 			throw err::RpcRelationsInvalidStrategy();
-			break;
 		}
 	}
 

--- a/src/svc/relations.cpp
+++ b/src/svc/relations.cpp
@@ -54,8 +54,8 @@ rpcCheck::result_type Impl::call<rpcCheck>(
 	response.set_found(false);
 
 	// Direct strategy
-	if (auto tuples = db::LookupTuples(
-			ctx.meta(common::space_id_v), left, req.relation(), right, std::nullopt, "", 1);
+	if (auto tuples =
+			db::LookupTuples(ctx.meta(common::space_id_v), left, req.relation(), right, {}, {}, 1);
 		!tuples.empty()) {
 
 		response.set_cost(cost);

--- a/src/svc/relations.h
+++ b/src/svc/relations.h
@@ -53,7 +53,7 @@ private:
 		const db::Tuples                                            &from,
 		google::protobuf::RepeatedPtrField<sentium::api::v1::Tuple> *to) const noexcept;
 
-	// Check for a relation between left & right entities using the `spot` algorithm.
+	// Check for a relation between left and right entities using the `spot` algorithm.
 	spot_t spot(
 		std::string_view spaceId, db::Tuple::Entity left, std::string_view relation,
 		db::Tuple::Entity right, std::uint16_t limit) const;

--- a/src/svc/relations.h
+++ b/src/svc/relations.h
@@ -39,6 +39,11 @@ public:
 	google::rpc::Status exception() noexcept;
 
 private:
+	struct spot_t {
+		std::int32_t             cost;
+		std::optional<db::Tuple> tuple;
+	};
+
 	db::Tuple map(const grpcxx::context &ctx, const rpcCreate::request_type &from) const noexcept;
 
 	rpcCreate::response_type map(const db::Tuple &from) const noexcept;
@@ -47,6 +52,11 @@ private:
 	void map(
 		const db::Tuples                                            &from,
 		google::protobuf::RepeatedPtrField<sentium::api::v1::Tuple> *to) const noexcept;
+
+	// Check for a relation between left & right entities using the `spot` algorithm.
+	spot_t spot(
+		std::string_view spaceId, db::Tuple::Entity left, std::string_view relation,
+		db::Tuple::Entity right, std::uint16_t limit) const;
 };
 } // namespace relations
 } // namespace svc

--- a/src/svc/relations_test.cpp
+++ b/src/svc/relations_test.cpp
@@ -39,6 +39,7 @@ TEST_F(svc_RelationsTest, Check) {
 		ASSERT_NO_THROW(tuple.store());
 
 		rpcCheck::request_type request;
+		request.set_strategy(static_cast<std::uint32_t>(svc::common::strategy_t::direct));
 
 		auto *left = request.mutable_left_entity();
 		left->set_id(tuple.lEntityId());

--- a/src/svc/relations_test.cpp
+++ b/src/svc/relations_test.cpp
@@ -223,6 +223,22 @@ TEST_F(svc_RelationsTest, Check) {
 		EXPECT_EQ(tuples[0].id(), actual.ref_id_left());
 		EXPECT_EQ(tuples[1].id(), actual.ref_id_right());
 	}
+
+	// Error: invalid strategy
+	{
+		rpcCheck::request_type request;
+		request.set_strategy(0);
+
+		rpcCheck::result_type result;
+		EXPECT_NO_THROW(result = svc.call<rpcCheck>(ctx, request));
+
+		EXPECT_EQ(grpcxx::status::code_t::invalid_argument, result.status.code());
+		EXPECT_EQ(
+			"CAMSLltzZW50aXVtOjIuMi4xLjQwMF0gSW52YWxpZCByZWxhdGlvbnMgc3RyYXRlZ3k=",
+			result.status.details());
+
+		EXPECT_FALSE(result.response);
+	}
 }
 
 TEST_F(svc_RelationsTest, Create) {
@@ -232,6 +248,7 @@ TEST_F(svc_RelationsTest, Create) {
 	// Success: create relation
 	{
 		rpcCreate::request_type request;
+		request.set_optimize(static_cast<std::uint32_t>(svc::common::strategy_t::graph));
 
 		auto *left = request.mutable_left_entity();
 		left->set_id("left");
@@ -786,6 +803,22 @@ TEST_F(svc_RelationsTest, Create) {
 
 		EXPECT_EQ(grpcxx::status::code_t::invalid_argument, result.status.code());
 		ASSERT_FALSE(result.response);
+	}
+
+	// Error: invalid optmization strategy
+	{
+		rpcCreate::request_type request;
+		request.set_optimize(0);
+
+		rpcCreate::result_type result;
+		EXPECT_NO_THROW(result = svc.call<rpcCreate>(ctx, request));
+
+		EXPECT_EQ(grpcxx::status::code_t::invalid_argument, result.status.code());
+		EXPECT_EQ(
+			"CAMSLltzZW50aXVtOjIuMi4xLjQwMF0gSW52YWxpZCByZWxhdGlvbnMgc3RyYXRlZ3k=",
+			result.status.details());
+
+		EXPECT_FALSE(result.response);
 	}
 }
 


### PR DESCRIPTION
Introduce `set` strategy for checking relations, which uses a set intersection algorithm to derive relations between entities if a direct relation cannot be found.

💡 Refer to tests for a visual example on how the `set` strategy works.