### PR TITLE
ReBAC: `graph` strategy for checking relations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,4 +80,4 @@ run: $(binary)
 	$(binary) -4 127.0.0.1
 
 test: $(binary)
-	ctest --test-dir $(builddir) --output-on-failure
+	ctest --test-dir $(builddir) --output-on-failure $(filter-out $@,$(MAKECMDGOALS))

--- a/proto/sentium/api/v1/relations.proto
+++ b/proto/sentium/api/v1/relations.proto
@@ -85,6 +85,8 @@ message RelationsCheckRequest {
 	//
 	// Strategies:
 	//   2 (direct) - Only check if there's a direct relation exists between the entities.
+	//   4 (graph)  - If a direct relation cannot be found between the entities, use a graph traversal
+	//                algorithm to derive a relation.
 	//   8 (set)    - Check if there's a direct relation exists between the entities and if not, use
 	//                a set intersection algorithm to derive a relation between the entities.
 	optional uint32 strategy = 6;

--- a/proto/sentium/api/v1/relations.proto
+++ b/proto/sentium/api/v1/relations.proto
@@ -104,6 +104,9 @@ message RelationsCheckResponse {
 	// Tuple containing relation data that matched the query. An empty tuple `id` indicates a computed
 	// tuple which isn't stored.
 	optional Tuple tuple = 3;
+
+	// Path that derived the relation between entities when using the `graph` lookup strategy.
+	repeated Tuple path = 4;
 }
 
 message RelationsCreateRequest {

--- a/src/svc/relations.h
+++ b/src/svc/relations.h
@@ -1,4 +1,8 @@
 #pragma once
+#include <optional>
+#include <queue>
+#include <string_view>
+
 #include <google/rpc/status.pb.h>
 
 #include "db/tuples.h"
@@ -39,6 +43,11 @@ public:
 	google::rpc::Status exception() noexcept;
 
 private:
+	struct graph_t {
+		std::int32_t          cost;
+		std::queue<db::Tuple> path;
+	};
+
 	struct spot_t {
 		std::int32_t             cost;
 		std::optional<db::Tuple> tuple;
@@ -52,6 +61,11 @@ private:
 	void map(
 		const db::Tuples                                            &from,
 		google::protobuf::RepeatedPtrField<sentium::api::v1::Tuple> *to) const noexcept;
+
+	// Check for a relation between left and right entities using the `graph` algorithm.
+	graph_t graph(
+		std::string_view spaceId, db::Tuple::Entity left, std::string_view relation,
+		db::Tuple::Entity right, std::uint16_t limit) const;
 
 	// Check for a relation between left and right entities using the `spot` algorithm.
 	spot_t spot(

--- a/src/svc/relations_test.cpp
+++ b/src/svc/relations_test.cpp
@@ -421,8 +421,8 @@ TEST_F(svc_RelationsTest, Check) {
 			request.set_relation("woner");
 
 			auto *right = request.mutable_right_entity();
-			right->set_id(tuples[2].rEntityId());
-			right->set_type(tuples[2].rEntityType());
+			right->set_id(tuples[3].rEntityId());
+			right->set_type(tuples[3].rEntityType());
 
 			EXPECT_NO_THROW(result = svc.call<rpcCheck>(ctx, request));
 


### PR DESCRIPTION
Introduce `graph` strategy for checking relations between two entities. The implementation uses a BFS graph traversal to derive relations if no direct relation is found.