### PR TITLE
Traverse relations graph right to left when checking relations

### DIFF
--- a/docs/rebac.md
+++ b/docs/rebac.md
@@ -61,6 +61,9 @@ To derive the relation `[]user:jane/reader/doc:notes.txt` using a BFS[^bfs] grap
 (which has **O(v+e)** complexity), we will need to read 10,003 tuples. This can be really slow depending
 on DB load and number of concurrent requests.
 
+> 💡 This is only an illustrative example. In reality, Sentium traverse the relations graphs from right
+> to left which will result in only 3 reads in this instance.
+
 ![Relations Graph #02](./assets/rebac-relations-graph-02.svg)
 
 In order to maintain a consistent and a predictable throughput (QPS), Sentium offers different optimisation

--- a/src/svc/relations.h
+++ b/src/svc/relations.h
@@ -1,6 +1,6 @@
 #pragma once
+#include <deque>
 #include <optional>
-#include <queue>
 #include <string_view>
 
 #include <google/rpc/status.pb.h>
@@ -45,7 +45,7 @@ public:
 private:
 	struct graph_t {
 		std::int32_t          cost;
-		std::queue<db::Tuple> path;
+		std::deque<db::Tuple> path;
 	};
 
 	struct spot_t {

--- a/src/svc/relations_test.cpp
+++ b/src/svc/relations_test.cpp
@@ -309,7 +309,7 @@ TEST_F(svc_RelationsTest, Check) {
 		//  member | group:writers  | member   | group:readers
 		//  member | group:readers  | reader   | doc:notes.txt
 		//  member | group:readers  | member   | group:loop
-		//  member | group:loop     | member   | group:writers
+		//  member | group:loop     | reader   | doc:notes.txt
 		//  owner  | group:writers  | owner    | doc:notes.txt
 		//
 		// Checks:
@@ -360,8 +360,8 @@ TEST_F(svc_RelationsTest, Check) {
 			{{
 				.lEntityId   = "group:loop",
 				.lEntityType = "svc_RelationsTest.Check-with_graph_strategy",
-				.relation    = "member",
-				.rEntityId   = "group:writers",
+				.relation    = "reader",
+				.rEntityId   = "doc:notes.txt",
 				.rEntityType = "svc_RelationsTest.Check-with_graph_strategy",
 				.strand      = "member",
 			}},
@@ -401,7 +401,7 @@ TEST_F(svc_RelationsTest, Check) {
 			EXPECT_EQ(grpcxx::status::code_t::ok, result.status.code());
 			ASSERT_TRUE(result.response);
 			EXPECT_EQ(true, result.response->found());
-			EXPECT_EQ(5, result.response->cost());
+			EXPECT_EQ(6, result.response->cost());
 			EXPECT_FALSE(result.response->has_tuple());
 			ASSERT_EQ(4, result.response->path().size());
 

--- a/src/svc/relations_test.cpp
+++ b/src/svc/relations_test.cpp
@@ -401,7 +401,7 @@ TEST_F(svc_RelationsTest, Check) {
 			EXPECT_EQ(grpcxx::status::code_t::ok, result.status.code());
 			ASSERT_TRUE(result.response);
 			EXPECT_EQ(true, result.response->found());
-			EXPECT_EQ(4, result.response->cost());
+			EXPECT_EQ(5, result.response->cost());
 			EXPECT_FALSE(result.response->has_tuple());
 			ASSERT_EQ(4, result.response->path().size());
 
@@ -429,7 +429,7 @@ TEST_F(svc_RelationsTest, Check) {
 			EXPECT_EQ(grpcxx::status::code_t::ok, result.status.code());
 			ASSERT_TRUE(result.response);
 			EXPECT_EQ(false, result.response->found());
-			EXPECT_EQ(7, result.response->cost());
+			EXPECT_EQ(1, result.response->cost());
 			EXPECT_FALSE(result.response->has_tuple());
 			EXPECT_TRUE(result.response->path().empty());
 		}

--- a/src/svc/relations_test.cpp
+++ b/src/svc/relations_test.cpp
@@ -311,6 +311,7 @@ TEST_F(svc_RelationsTest, Check) {
 		//  member | group:readers  | member   | group:loop
 		//  member | group:loop     | reader   | doc:notes.txt
 		//  owner  | group:writers  | owner    | doc:notes.txt
+		//  owner  | group:writers  | reader   | doc:notes.txt
 		//
 		// Checks:
 		//   1. []user:jane/reader/doc:notes.txt - ✓
@@ -373,6 +374,14 @@ TEST_F(svc_RelationsTest, Check) {
 				.rEntityType = "svc_RelationsTest.Check-with_graph_strategy",
 				.strand      = "owner",
 			}},
+			{{
+				.lEntityId   = "group:writers",
+				.lEntityType = "svc_RelationsTest.Check-with_graph_strategy",
+				.relation    = "reader",
+				.rEntityId   = "doc:notes.txt",
+				.rEntityType = "svc_RelationsTest.Check-with_graph_strategy",
+				.strand      = "owner",
+			}},
 		});
 
 		for (auto &t : tuples) {
@@ -401,7 +410,7 @@ TEST_F(svc_RelationsTest, Check) {
 			EXPECT_EQ(grpcxx::status::code_t::ok, result.status.code());
 			ASSERT_TRUE(result.response);
 			EXPECT_EQ(true, result.response->found());
-			EXPECT_EQ(6, result.response->cost());
+			EXPECT_EQ(7, result.response->cost());
 			EXPECT_FALSE(result.response->has_tuple());
 			ASSERT_EQ(4, result.response->path().size());
 


### PR DESCRIPTION
This is a slight optimisation to reduce the BFS graph traversal cost with the expectation that the graph is narrower on the left and wider on the right. Most of the time this would be the case if principals are on the left. 

e.g. 
In the following example, to check `user:jane -> reader -> doc:notes.txt` with left to right BFS will require 10003 lookups whereas right to left will only take 3 lookups.

![Relations graph, wider on the right](https://raw.githubusercontent.com/uatuko/sentium/bef39377400889cb735451fd15a706b8b2635728/docs/assets/rebac-relations-graph-02.svg)

## Benchmarks

<details>
<summary>Before</summary>

```
-------------------------------------------------------------------------------------------
Benchmark                                 Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------
bm_relations/check_graph/4/128     25076263 ns      3086440 ns          100 ops=323.998/s vertices=126.359k/s
bm_relations/check_graph/8/128     57364218 ns      7036899 ns           99 ops=142.108/s vertices=128.75k/s
bm_relations/check_graph/32/128   259431654 ns     33223300 ns           10 ops=30.0994/s vertices=120.458k/s
bm_relations/check_graph/4/512    101723773 ns     12166667 ns           57 ops=82.1918/s vertices=126.74k/s
bm_relations/check_graph/8/512    237103853 ns     27974560 ns           25 ops=35.7468/s vertices=128.474k/s
bm_relations/check_graph/32/512  1078407325 ns    137229800 ns            5 ops=7.28705/s vertices=115.908k/s
bm_relations/check_graph/4/2048   421086234 ns     51664538 ns           13 ops=19.3556/s vertices=119.037k/s
bm_relations/check_graph/8/2048   974933250 ns    118474000 ns            6 ops=8.44067/s vertices=121.09k/s
bm_relations/check_graph/32/2048 4466643000 ns    611284000 ns            1 ops=1.6359/s vertices=103.916k/s
```
</details>

```
-------------------------------------------------------------------------------------------
Benchmark                                 Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------
bm_relations/check_graph/4/128       414345 ns        58750 ns        12076 ops=17.0214k/s vertices=102.128k/s
bm_relations/check_graph/8/128       646869 ns        91978 ns         7637 ops=10.8721k/s vertices=108.721k/s
bm_relations/check_graph/32/128     2107918 ns       321862 ns         2148 ops=3.10692k/s vertices=105.635k/s
bm_relations/check_graph/4/512       425155 ns        59755 ns        12022 ops=16.7349k/s vertices=100.41k/s
bm_relations/check_graph/8/512       664887 ns        92465 ns         7602 ops=10.8149k/s vertices=108.149k/s
bm_relations/check_graph/32/512     2142939 ns       311927 ns         2217 ops=3.20587k/s vertices=109k/s
bm_relations/check_graph/4/2048      430403 ns        58354 ns        12093 ops=17.1369k/s vertices=102.821k/s
bm_relations/check_graph/8/2048      678464 ns        91770 ns         7622 ops=10.8968k/s vertices=108.968k/s
bm_relations/check_graph/32/2048    2190622 ns       312404 ns         2219 ops=3.20098k/s vertices=108.833k/s
```