### PR TITLE
Use hash values to speed-up to comparing entities

### DIFF
--- a/bench/algorithms_test.cpp
+++ b/bench/algorithms_test.cpp
@@ -111,3 +111,46 @@ BENCHMARK([](benchmark::State &st) {
 })
 	->Name("bm_spot_intersection")
 	->Range(8, 8 << 10);
+
+BENCHMARK([](benchmark::State &st) {
+	std::vector<int> left;
+	std::vector<int> right;
+
+	left.reserve(st.range(0));
+	right.reserve(st.range(0));
+
+	for (int n = st.range(0); n > 0; n--) {
+		left.emplace_back(std::rand());
+		right.emplace_back(std::rand());
+	}
+
+	std::size_t ops  = 0;
+	std::size_t cost = 0;
+	for (auto _ : st) {
+		ops++;
+
+		auto i = left.cbegin();
+		auto j = right.cbegin();
+
+		while (i != left.cend() && j != right.cend()) {
+			cost++;
+
+			if (*i == *j) {
+				break;
+			}
+
+			if (*i < *j) {
+				i++;
+			} else {
+				j++;
+			}
+		}
+	}
+
+	st.counters.insert({
+		{"ops", benchmark::Counter(ops, benchmark::Counter::kIsRate)},
+		{"comparisons", benchmark::Counter(cost, benchmark::Counter::kIsRate)},
+	});
+})
+	->Name("bm_spot_intersection_int")
+	->Range(8, 8 << 10);

--- a/bench/algorithms_test.cpp
+++ b/bench/algorithms_test.cpp
@@ -81,16 +81,16 @@ BENCHMARK([](benchmark::State &st) {
 		right.emplace_back(xid::next());
 	}
 
-	std::size_t ops = 0;
+	std::size_t ops  = 0;
+	std::size_t cost = 0;
 	for (auto _ : st) {
-		st.PauseTiming();
 		ops++;
-		st.ResumeTiming();
 
 		auto i = left.cbegin();
 		auto j = right.cbegin();
 
 		while (i != left.cend() && j != right.cend()) {
+			cost++;
 			auto r = i->compare(*j);
 
 			if (r == 0) {
@@ -107,14 +107,15 @@ BENCHMARK([](benchmark::State &st) {
 
 	st.counters.insert({
 		{"ops", benchmark::Counter(ops, benchmark::Counter::kIsRate)},
+		{"comparisons", benchmark::Counter(cost, benchmark::Counter::kIsRate)},
 	});
 })
 	->Name("bm_spot_intersection")
 	->Range(8, 8 << 10);
 
 BENCHMARK([](benchmark::State &st) {
-	std::vector<int> left;
-	std::vector<int> right;
+	std::vector<std::int64_t> left;
+	std::vector<std::int64_t> right;
 
 	left.reserve(st.range(0));
 	right.reserve(st.range(0));
@@ -152,5 +153,5 @@ BENCHMARK([](benchmark::State &st) {
 		{"comparisons", benchmark::Counter(cost, benchmark::Counter::kIsRate)},
 	});
 })
-	->Name("bm_spot_intersection_int")
+	->Name("bm_spot_intersection_int64")
 	->Range(8, 8 << 10);

--- a/bench/algorithms_test.cpp
+++ b/bench/algorithms_test.cpp
@@ -125,6 +125,9 @@ BENCHMARK([](benchmark::State &st) {
 		right.emplace_back(std::rand());
 	}
 
+	std::sort(left.begin(), left.end());
+	std::sort(right.begin(), right.end());
+
 	std::size_t ops  = 0;
 	std::size_t cost = 0;
 	for (auto _ : st) {

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -77,5 +77,4 @@ create table if not exists tuples (
 	constraint "tuples.check-attrs" check (jsonb_typeof(attrs) = 'object')
 );
 
-create index "tuples.idx-ltr" on tuples using btree (space_id, _l_hash, relation, _r_hash, _id);
-create index "tuples.idx-rtl" on tuples using btree (space_id, _r_hash, relation, strand, _l_hash, _id);
+create index "tuples.idx-rtl" on tuples using btree (space_id, _r_hash, relation, _l_hash, strand, _id);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -38,6 +38,11 @@ create table if not exists tuples (
 	_id   text    not null,
 	_rev  integer not null,
 
+	-- Hash values of entities
+	--
+	_hash_l bigint,
+	_hash_r bigint,
+
 	-- Self references for computed tuples
 	--
 	_rid_l  text,
@@ -71,3 +76,6 @@ create table if not exists tuples (
 	constraint "tuples.check-r_entity_id" check (r_entity_id <> ''),
 	constraint "tuples.check-attrs" check (jsonb_typeof(attrs) = 'object')
 );
+
+create index "tuples.idx-ltr" on tuples using btree (space_id, _hash_l, relation, _hash_r, _id);
+create index "tuples.idx-rtl" on tuples using btree (space_id, _hash_r, relation, strand, _hash_l, _id);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -40,8 +40,8 @@ create table if not exists tuples (
 
 	-- Hash values of entities
 	--
-	_hash_l bigint,
-	_hash_r bigint,
+	_l_hash bigint,
+	_r_hash bigint,
 
 	-- Self references for computed tuples
 	--
@@ -77,5 +77,5 @@ create table if not exists tuples (
 	constraint "tuples.check-attrs" check (jsonb_typeof(attrs) = 'object')
 );
 
-create index "tuples.idx-ltr" on tuples using btree (space_id, _hash_l, relation, _hash_r, _id);
-create index "tuples.idx-rtl" on tuples using btree (space_id, _hash_r, relation, strand, _hash_l, _id);
+create index "tuples.idx-ltr" on tuples using btree (space_id, _l_hash, relation, _r_hash, _id);
+create index "tuples.idx-rtl" on tuples using btree (space_id, _r_hash, relation, strand, _l_hash, _id);

--- a/src/db/CMakeLists.txt
+++ b/src/db/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(db
 		pg.cpp
 		principals.cpp
 		tuples.cpp
+		tuplets.cpp
 	PUBLIC
 		FILE_SET headers TYPE HEADERS
 		FILES
@@ -11,6 +12,7 @@ target_sources(db
 			pg.h
 			principals.h
 			tuples.h
+			tuplets.h
 	PRIVATE
 		FILE_SET private_headers TYPE HEADERS
 		FILES
@@ -51,6 +53,7 @@ if (SENTIUM_BUILD_TESTING)
 			pg_test.cpp
 			principals_test.cpp
 			tuples_test.cpp
+			tuplets_test.cpp
 	)
 
 	target_link_libraries(db_tests

--- a/src/db/tuples.cpp
+++ b/src/db/tuples.cpp
@@ -8,12 +8,13 @@
 #include "common.h"
 
 namespace db {
-Tuple::Tuple(const Tuple::Data &data) noexcept : _data(data), _id(), _rev(0), _ridL(), _ridR() {
+Tuple::Tuple(const Tuple::Data &data) noexcept :
+	_data(data), _hashL(), _hashR(), _id(), _rev(0), _ridL(), _ridR() {
 	sanitise();
 }
 
 Tuple::Tuple(Tuple::Data &&data) noexcept :
-	_data(std::move(data)), _id(), _rev(0), _ridL(), _ridR() {
+	_data(std::move(data)), _hashL(), _hashR(), _id(), _rev(0), _ridL(), _ridR() {
 	sanitise();
 }
 
@@ -30,6 +31,7 @@ Tuple::Tuple(const pg::row_t &r) :
 		.spaceId      = r["space_id"].as<std::string>(),
 		.strand       = r["strand"].as<std::string>(),
 	}),
+	_hashL(r["_hash_l"].as<std::int64_t>()), _hashR(r["_hash_r"].as<std::int64_t>()),
 	_id(r["_id"].as<std::string>()), _rev(r["_rev"].as<int>()), _ridL(r["_rid_l"].as<rid_t>()),
 	_ridR(r["_rid_r"].as<rid_t>()) {}
 
@@ -44,7 +46,8 @@ Tuple::Tuple(const Tuple &left, const Tuple &right) noexcept :
 		.rPrincipalId = right.rPrincipalId(),
 		.spaceId      = left.spaceId(),
 	}),
-	_id(), _rev(0), _ridL(left.id()), _ridR(right.id()) {}
+	_hashL(left.hashL()), _hashR(right.hashR()), _id(), _rev(0), _ridL(left.id()),
+	_ridR(right.id()) {}
 
 bool Tuple::discard(std::string_view id) {
 	std::string_view qry = R"(
@@ -55,6 +58,11 @@ bool Tuple::discard(std::string_view id) {
 
 	auto res = pg::exec(qry, id);
 	return (res.affected_rows() == 1);
+}
+
+void Tuple::hash() noexcept {
+	_hashL = Entity(_data.lEntityType, _data.lEntityId).hash();
+	_hashR = Entity(_data.rEntityType, _data.rEntityId).hash();
 }
 
 std::optional<Tuple> Tuple::lookup(
@@ -80,6 +88,7 @@ Tuple Tuple::retrieve(std::string_view id) {
 			attrs,
 			l_principal_id, r_principal_id,
 			_id, _rev,
+			_hash_l, _hash_r,
 			_rid_l, _rid_r
 		from tuples
 		where _id = $1::text;
@@ -103,6 +112,8 @@ void Tuple::sanitise() noexcept {
 		_data.rEntityId   = *_data.rPrincipalId;
 		_data.rEntityType = common::principal_entity_v;
 	}
+
+	hash();
 }
 
 void Tuple::store() {
@@ -120,6 +131,7 @@ void Tuple::store() {
 			attrs,
 			l_principal_id, r_principal_id,
 			_id, _rev,
+			_hash_l, _hash_r,
 			_rid_l, _rid_r
 		) values (
 			$1::text,
@@ -130,7 +142,8 @@ void Tuple::store() {
 			$8::jsonb,
 			$9::text, $10::text,
 			$11::text, $12::integer,
-			$13::text, $14::text
+			$13::bigint, $14::bigint,
+			$15::text, $16::text
 		)
 		on conflict (_id)
 		do update
@@ -161,6 +174,8 @@ void Tuple::store() {
 			_data.rPrincipalId,
 			_id,
 			_rev,
+			_hashL,
+			_hashR,
 			_ridL,
 			_ridR);
 	} catch (pqxx::check_violation &) {
@@ -182,6 +197,26 @@ Tuple::Entity::Entity(std::string_view pid) noexcept :
 	_id(pid), _type(common::principal_entity_v) {}
 
 Tuple::Entity::Entity(std::string_view type, std::string_view id) noexcept : _id(id), _type(type) {}
+
+std::int64_t Tuple::Entity::hash() const noexcept {
+	// Jon Maiga's bit mixer from mx3
+	// Ref: https://github.com/jonmaiga/mx3/blob/48924ee743d724aea2cafd2b4249ef8df57fa8b9/mx3.h#L17
+	auto mix = [](std::int64_t x) -> std::int64_t {
+		constexpr std::int64_t m = 0xbea225f9eb34556d;
+
+		x ^= x >> 32;
+		x *= m;
+		x ^= x >> 29;
+		x *= m;
+		x ^= x >> 32;
+		x *= m;
+		x ^= x >> 29;
+		return x;
+	};
+
+	std::int64_t seed = std::hash<std::string_view>()(type());
+	return mix(seed + 0x517cc1b727220a95 + std::hash<std::string_view>()(id()));
+}
 
 Tuples ListTuples(
 	std::string_view spaceId, std::optional<Tuple::Entity> left, std::optional<Tuple::Entity> right,
@@ -229,6 +264,7 @@ Tuples ListTuples(
 				attrs,
 				l_principal_id, r_principal_id,
 				_id, _rev,
+				_hash_l, _hash_r,
 				_rid_l, _rid_r
 			from tuples
 			{}
@@ -303,6 +339,7 @@ Tuples LookupTuples(
 				attrs,
 				l_principal_id, r_principal_id,
 				_id, _rev,
+				_hash_l, _hash_r,
 				_rid_l, _rid_r
 			from tuples
 			{}

--- a/src/db/tuples.cpp
+++ b/src/db/tuples.cpp
@@ -264,7 +264,7 @@ Tuples ListTuples(
 				attrs,
 				l_principal_id, r_principal_id,
 				_id, _rev,
-				_hash_l, _hash_r,
+				_l_hash, _r_hash,
 				_rid_l, _rid_r
 			from tuples
 			{}

--- a/src/db/tuples.cpp
+++ b/src/db/tuples.cpp
@@ -9,12 +9,12 @@
 
 namespace db {
 Tuple::Tuple(const Tuple::Data &data) noexcept :
-	_data(data), _lHash(), _rHash(), _id(), _rev(0), _ridL(), _ridR() {
+	_data(data), _id(), _rev(0), _lHash(), _rHash(), _ridL(), _ridR() {
 	sanitise();
 }
 
 Tuple::Tuple(Tuple::Data &&data) noexcept :
-	_data(std::move(data)), _lHash(), _rHash(), _id(), _rev(0), _ridL(), _ridR() {
+	_data(std::move(data)), _id(), _rev(0), _lHash(), _rHash(), _ridL(), _ridR() {
 	sanitise();
 }
 
@@ -31,9 +31,9 @@ Tuple::Tuple(const pg::row_t &r) :
 		.spaceId      = r["space_id"].as<std::string>(),
 		.strand       = r["strand"].as<std::string>(),
 	}),
+	_id(r["_id"].as<std::string>()), _rev(r["_rev"].as<int>()),
 	_lHash(r["_l_hash"].as<std::int64_t>()), _rHash(r["_r_hash"].as<std::int64_t>()),
-	_id(r["_id"].as<std::string>()), _rev(r["_rev"].as<int>()), _ridL(r["_rid_l"].as<rid_t>()),
-	_ridR(r["_rid_r"].as<rid_t>()) {}
+	_ridL(r["_rid_l"].as<rid_t>()), _ridR(r["_rid_r"].as<rid_t>()) {}
 
 Tuple::Tuple(const Tuple &left, const Tuple &right) noexcept :
 	_data({
@@ -46,7 +46,7 @@ Tuple::Tuple(const Tuple &left, const Tuple &right) noexcept :
 		.rPrincipalId = right.rPrincipalId(),
 		.spaceId      = left.spaceId(),
 	}),
-	_lHash(left.lHash()), _rHash(right.rHash()), _id(), _rev(0), _ridL(left.id()),
+	_id(), _rev(0), _lHash(left.lHash()), _rHash(right.rHash()), _ridL(left.id()),
 	_ridR(right.id()) {}
 
 bool Tuple::discard(std::string_view id) {

--- a/src/db/tuples.cpp
+++ b/src/db/tuples.cpp
@@ -230,26 +230,28 @@ Tuples ListTuples(
 	std::string   where = "where space_id = $1::text";
 	std::string   sort;
 	if (left) {
-		entity  = *left;
-		where  += " and l_entity_type = $2::text and l_entity_id = $3::text";
-		sort    = "r_entity_id";
+		entity = *left;
+		where +=
+			" and _l_hash = $2::bigint and l_entity_type = $3::text and l_entity_id = $4::text";
+		sort = "r_entity_id";
 	} else if (right) {
-		entity  = *right;
-		where  += " and r_entity_type = $2::text and r_entity_id = $3::text";
-		sort    = "l_entity_id";
+		entity = *right;
+		where +=
+			" and _r_hash = $2::bigint and r_entity_type = $3::text and r_entity_id = $4::text";
+		sort = "l_entity_id";
 	} else {
 		throw err::DbTuplesInvalidListArgs();
 	}
 
 	if (relation) {
-		where += " and relation = $4::text";
+		where += " and relation = $5::text";
 	}
 
 	if (!lastId.empty()) {
 		if (relation) {
-			where += fmt::format(" and {} < $5::text", sort);
+			where += fmt::format(" and {} < $6::text", sort);
 		} else {
-			where += fmt::format(" and {} < $4::text", sort);
+			where += fmt::format(" and {} < $5::text", sort);
 		}
 	}
 
@@ -277,13 +279,13 @@ Tuples ListTuples(
 
 	db::pg::result_t res;
 	if (relation && !lastId.empty()) {
-		res = pg::exec(qry, spaceId, entity.type(), entity.id(), relation, lastId);
+		res = pg::exec(qry, spaceId, entity.hash(), entity.type(), entity.id(), relation, lastId);
 	} else if (relation) {
-		res = pg::exec(qry, spaceId, entity.type(), entity.id(), relation);
+		res = pg::exec(qry, spaceId, entity.hash(), entity.type(), entity.id(), relation);
 	} else if (!lastId.empty()) {
-		res = pg::exec(qry, spaceId, entity.type(), entity.id(), lastId);
+		res = pg::exec(qry, spaceId, entity.hash(), entity.type(), entity.id(), lastId);
 	} else {
-		res = pg::exec(qry, spaceId, entity.type(), entity.id());
+		res = pg::exec(qry, spaceId, entity.hash(), entity.type(), entity.id());
 	}
 
 	Tuples tuples;

--- a/src/db/tuples.cpp
+++ b/src/db/tuples.cpp
@@ -9,12 +9,12 @@
 
 namespace db {
 Tuple::Tuple(const Tuple::Data &data) noexcept :
-	_data(data), _hashL(), _hashR(), _id(), _rev(0), _ridL(), _ridR() {
+	_data(data), _lHash(), _rHash(), _id(), _rev(0), _ridL(), _ridR() {
 	sanitise();
 }
 
 Tuple::Tuple(Tuple::Data &&data) noexcept :
-	_data(std::move(data)), _hashL(), _hashR(), _id(), _rev(0), _ridL(), _ridR() {
+	_data(std::move(data)), _lHash(), _rHash(), _id(), _rev(0), _ridL(), _ridR() {
 	sanitise();
 }
 
@@ -31,7 +31,7 @@ Tuple::Tuple(const pg::row_t &r) :
 		.spaceId      = r["space_id"].as<std::string>(),
 		.strand       = r["strand"].as<std::string>(),
 	}),
-	_hashL(r["_hash_l"].as<std::int64_t>()), _hashR(r["_hash_r"].as<std::int64_t>()),
+	_lHash(r["_l_hash"].as<std::int64_t>()), _rHash(r["_r_hash"].as<std::int64_t>()),
 	_id(r["_id"].as<std::string>()), _rev(r["_rev"].as<int>()), _ridL(r["_rid_l"].as<rid_t>()),
 	_ridR(r["_rid_r"].as<rid_t>()) {}
 
@@ -46,7 +46,7 @@ Tuple::Tuple(const Tuple &left, const Tuple &right) noexcept :
 		.rPrincipalId = right.rPrincipalId(),
 		.spaceId      = left.spaceId(),
 	}),
-	_hashL(left.hashL()), _hashR(right.hashR()), _id(), _rev(0), _ridL(left.id()),
+	_lHash(left.lHash()), _rHash(right.rHash()), _id(), _rev(0), _ridL(left.id()),
 	_ridR(right.id()) {}
 
 bool Tuple::discard(std::string_view id) {
@@ -61,8 +61,8 @@ bool Tuple::discard(std::string_view id) {
 }
 
 void Tuple::hash() noexcept {
-	_hashL = Entity(_data.lEntityType, _data.lEntityId).hash();
-	_hashR = Entity(_data.rEntityType, _data.rEntityId).hash();
+	_lHash = Entity(_data.lEntityType, _data.lEntityId).hash();
+	_rHash = Entity(_data.rEntityType, _data.rEntityId).hash();
 }
 
 std::optional<Tuple> Tuple::lookup(
@@ -88,7 +88,7 @@ Tuple Tuple::retrieve(std::string_view id) {
 			attrs,
 			l_principal_id, r_principal_id,
 			_id, _rev,
-			_hash_l, _hash_r,
+			_l_hash, _r_hash,
 			_rid_l, _rid_r
 		from tuples
 		where _id = $1::text;
@@ -131,7 +131,7 @@ void Tuple::store() {
 			attrs,
 			l_principal_id, r_principal_id,
 			_id, _rev,
-			_hash_l, _hash_r,
+			_l_hash, _r_hash,
 			_rid_l, _rid_r
 		) values (
 			$1::text,
@@ -174,8 +174,8 @@ void Tuple::store() {
 			_data.rPrincipalId,
 			_id,
 			_rev,
-			_hashL,
-			_hashR,
+			_lHash,
+			_rHash,
 			_ridL,
 			_ridR);
 	} catch (pqxx::check_violation &) {
@@ -339,7 +339,7 @@ Tuples LookupTuples(
 				attrs,
 				l_principal_id, r_principal_id,
 				_id, _rev,
-				_hash_l, _hash_r,
+				_l_hash, _r_hash,
 				_rid_l, _rid_r
 			from tuples
 			{}

--- a/src/db/tuples.cpp
+++ b/src/db/tuples.cpp
@@ -227,18 +227,19 @@ Tuples ListTuples(
 	}
 
 	Tuple::Entity entity;
+	std::int64_t  hash  = 0;
 	std::string   where = "where space_id = $1::text";
 	std::string   sort;
 	if (left) {
-		entity = *left;
-		where +=
-			" and _l_hash = $2::bigint and l_entity_type = $3::text and l_entity_id = $4::text";
-		sort = "r_entity_id";
+		entity  = *left;
+		sort    = "r_entity_id";
+		where  += " and 0 = $2::bigint and l_entity_type = $3::text and l_entity_id = $4::text";
 	} else if (right) {
 		entity = *right;
+		hash   = entity.hash();
+		sort   = "l_entity_id";
 		where +=
 			" and _r_hash = $2::bigint and r_entity_type = $3::text and r_entity_id = $4::text";
-		sort = "l_entity_id";
 	} else {
 		throw err::DbTuplesInvalidListArgs();
 	}
@@ -279,13 +280,13 @@ Tuples ListTuples(
 
 	db::pg::result_t res;
 	if (relation && !lastId.empty()) {
-		res = pg::exec(qry, spaceId, entity.hash(), entity.type(), entity.id(), relation, lastId);
+		res = pg::exec(qry, spaceId, hash, entity.type(), entity.id(), relation, lastId);
 	} else if (relation) {
-		res = pg::exec(qry, spaceId, entity.hash(), entity.type(), entity.id(), relation);
+		res = pg::exec(qry, spaceId, hash, entity.type(), entity.id(), relation);
 	} else if (!lastId.empty()) {
-		res = pg::exec(qry, spaceId, entity.hash(), entity.type(), entity.id(), lastId);
+		res = pg::exec(qry, spaceId, hash, entity.type(), entity.id(), lastId);
 	} else {
-		res = pg::exec(qry, spaceId, entity.hash(), entity.type(), entity.id());
+		res = pg::exec(qry, spaceId, hash, entity.type(), entity.id());
 	}
 
 	Tuples tuples;

--- a/src/db/tuples.h
+++ b/src/db/tuples.h
@@ -42,6 +42,8 @@ public:
 		std::string_view id() const noexcept { return _id; }
 		std::string_view type() const noexcept { return _type; }
 
+		std::int64_t hash() const noexcept;
+
 	private:
 		std::string_view _id;
 		std::string_view _type;
@@ -85,6 +87,8 @@ public:
 	void               strand(const std::string &strand) noexcept { _data.strand = strand; }
 
 	const std::string &id() const noexcept { return _id; }
+	const std::int64_t hashL() const noexcept { return _hashL; }
+	const std::int64_t hashR() const noexcept { return _hashR; }
 	const int         &rev() const noexcept { return _rev; }
 	const rid_t       &ridL() const noexcept { return _ridL; }
 	const rid_t       &ridR() const noexcept { return _ridR; }
@@ -100,13 +104,15 @@ public:
 	static Tuple retrieve(std::string_view id);
 
 private:
+	void hash() noexcept;
+
 	void sanitise() noexcept;
 
-	Data        _data;
-	std::string _id;
-	int         _rev;
-	rid_t       _ridL;
-	rid_t       _ridR;
+	Data         _data;
+	std::int64_t _hashL, _hashR;
+	std::string  _id;
+	int          _rev;
+	rid_t        _ridL, _ridR;
 };
 
 using Tuples = std::vector<Tuple>;

--- a/src/db/tuples.h
+++ b/src/db/tuples.h
@@ -87,11 +87,13 @@ public:
 	void               strand(const std::string &strand) noexcept { _data.strand = strand; }
 
 	const std::string &id() const noexcept { return _id; }
-	const std::int64_t hashL() const noexcept { return _hashL; }
-	const std::int64_t hashR() const noexcept { return _hashR; }
 	const int         &rev() const noexcept { return _rev; }
-	const rid_t       &ridL() const noexcept { return _ridL; }
-	const rid_t       &ridR() const noexcept { return _ridR; }
+
+	const std::int64_t lHash() const noexcept { return _lHash; }
+	const std::int64_t rHash() const noexcept { return _rHash; }
+
+	const rid_t &ridL() const noexcept { return _ridL; }
+	const rid_t &ridR() const noexcept { return _ridR; }
 
 	void store();
 
@@ -109,9 +111,9 @@ private:
 	void sanitise() noexcept;
 
 	Data         _data;
-	std::int64_t _hashL, _hashR;
 	std::string  _id;
 	int          _rev;
+	std::int64_t _lHash, _rHash;
 	rid_t        _ridL, _ridR;
 };
 

--- a/src/db/tuples_test.cpp
+++ b/src/db/tuples_test.cpp
@@ -550,8 +550,9 @@ TEST_F(db_TuplesTest, sanitise) {
 		EXPECT_EQ(tuple.lPrincipalId(), tuple.lEntityId());
 		EXPECT_EQ(db::common::principal_entity_v, tuple.rEntityType());
 		EXPECT_EQ(tuple.rPrincipalId(), tuple.rEntityId());
-		EXPECT_EQ(4978332106395442344, tuple.lHash());
-		EXPECT_EQ(459406847117771879, tuple.rHash());
+
+		EXPECT_EQ(db::Tuple::Entity(tuple.lEntityType(), tuple.lEntityId()).hash(), tuple.lHash());
+		EXPECT_EQ(db::Tuple::Entity(tuple.rEntityType(), tuple.rEntityId()).hash(), tuple.rHash());
 	}
 }
 

--- a/src/db/tuples_test.cpp
+++ b/src/db/tuples_test.cpp
@@ -57,6 +57,8 @@ TEST_F(db_TuplesTest, constructor) {
 		EXPECT_EQ(right.rEntityType(), joined.rEntityType());
 		EXPECT_EQ(left.spaceId(), joined.spaceId());
 		EXPECT_TRUE(joined.strand().empty());
+		EXPECT_EQ(left.hashL(), joined.hashL());
+		EXPECT_EQ(right.hashR(), joined.hashR());
 		EXPECT_EQ(left.id(), joined.ridL());
 		EXPECT_EQ(right.id(), joined.ridR());
 
@@ -434,7 +436,8 @@ TEST_F(db_TuplesTest, retrieve) {
 				relation,
 				r_entity_type, r_entity_id,
 				attrs,
-				_id, _rev
+				_id, _rev,
+				_hash_l, _hash_r
 			) values (
 				$1::text,
 				$2::text,
@@ -442,7 +445,8 @@ TEST_F(db_TuplesTest, retrieve) {
 				$5::text,
 				$6::text, $7::text,
 				$8::jsonb,
-				$9::text, $10::integer
+				$9::text, $10::integer,
+				$11::bigint, $12::bigint
 			);
 		)";
 
@@ -457,12 +461,16 @@ TEST_F(db_TuplesTest, retrieve) {
 			"right",
 			R"({"foo": "bar"})",
 			"_id:db_TuplesTest.retrieve",
-			1729));
+			1729,
+			-3631866150419398620,
+			7468059380061813551));
 
 		auto tuple = db::Tuple::retrieve("_id:db_TuplesTest.retrieve");
 		EXPECT_FALSE(tuple.ridL());
 		EXPECT_FALSE(tuple.ridR());
 		EXPECT_EQ(1729, tuple.rev());
+		EXPECT_EQ(-3631866150419398620, tuple.hashL());
+		EXPECT_EQ(7468059380061813551, tuple.hashR());
 
 		EXPECT_EQ("db_TuplesTest.retrieve", tuple.lEntityType());
 		EXPECT_EQ("left", tuple.lEntityId());
@@ -542,6 +550,8 @@ TEST_F(db_TuplesTest, sanitise) {
 		EXPECT_EQ(tuple.lPrincipalId(), tuple.lEntityId());
 		EXPECT_EQ(db::common::principal_entity_v, tuple.rEntityType());
 		EXPECT_EQ(tuple.rPrincipalId(), tuple.rEntityId());
+		EXPECT_EQ(4978332106395442344, tuple.hashL());
+		EXPECT_EQ(459406847117771879, tuple.hashR());
 	}
 }
 
@@ -567,6 +577,7 @@ TEST_F(db_TuplesTest, store) {
 				attrs,
 				l_principal_id, r_principal_id,
 				_id, _rev,
+				_hash_l, _hash_r,
 				_rid_l, _rid_r
 			from tuples
 			where _id = $1::text;
@@ -588,6 +599,8 @@ TEST_F(db_TuplesTest, store) {
 			 rPrincipalId,
 			 _id,
 			 _rev,
+			 _hashL,
+			 _hashR,
 			 _ridL,
 			 _ridR] =
 				res[0]
@@ -603,6 +616,8 @@ TEST_F(db_TuplesTest, store) {
 						db::Tuple::Data::pid_t,
 						std::string,
 						int,
+						std::int64_t,
+						std::int64_t,
 						db::Tuple::rid_t,
 						db::Tuple::rid_t>();
 
@@ -618,6 +633,8 @@ TEST_F(db_TuplesTest, store) {
 		EXPECT_EQ(tuple.rPrincipalId(), rPrincipalId);
 		EXPECT_EQ(tuple.id(), _id);
 		EXPECT_EQ(tuple.rev(), _rev);
+		EXPECT_EQ(tuple.hashL(), _hashL);
+		EXPECT_EQ(tuple.hashR(), _hashR);
 		EXPECT_EQ(tuple.ridL(), _ridL);
 		EXPECT_EQ(tuple.ridR(), _ridR);
 	}

--- a/src/db/tuples_test.cpp
+++ b/src/db/tuples_test.cpp
@@ -57,8 +57,8 @@ TEST_F(db_TuplesTest, constructor) {
 		EXPECT_EQ(right.rEntityType(), joined.rEntityType());
 		EXPECT_EQ(left.spaceId(), joined.spaceId());
 		EXPECT_TRUE(joined.strand().empty());
-		EXPECT_EQ(left.hashL(), joined.hashL());
-		EXPECT_EQ(right.hashR(), joined.hashR());
+		EXPECT_EQ(left.lHash(), joined.lHash());
+		EXPECT_EQ(right.rHash(), joined.rHash());
 		EXPECT_EQ(left.id(), joined.ridL());
 		EXPECT_EQ(right.id(), joined.ridR());
 
@@ -437,7 +437,7 @@ TEST_F(db_TuplesTest, retrieve) {
 				r_entity_type, r_entity_id,
 				attrs,
 				_id, _rev,
-				_hash_l, _hash_r
+				_l_hash, _r_hash
 			) values (
 				$1::text,
 				$2::text,
@@ -469,8 +469,8 @@ TEST_F(db_TuplesTest, retrieve) {
 		EXPECT_FALSE(tuple.ridL());
 		EXPECT_FALSE(tuple.ridR());
 		EXPECT_EQ(1729, tuple.rev());
-		EXPECT_EQ(-3631866150419398620, tuple.hashL());
-		EXPECT_EQ(7468059380061813551, tuple.hashR());
+		EXPECT_EQ(-3631866150419398620, tuple.lHash());
+		EXPECT_EQ(7468059380061813551, tuple.rHash());
 
 		EXPECT_EQ("db_TuplesTest.retrieve", tuple.lEntityType());
 		EXPECT_EQ("left", tuple.lEntityId());
@@ -550,8 +550,8 @@ TEST_F(db_TuplesTest, sanitise) {
 		EXPECT_EQ(tuple.lPrincipalId(), tuple.lEntityId());
 		EXPECT_EQ(db::common::principal_entity_v, tuple.rEntityType());
 		EXPECT_EQ(tuple.rPrincipalId(), tuple.rEntityId());
-		EXPECT_EQ(4978332106395442344, tuple.hashL());
-		EXPECT_EQ(459406847117771879, tuple.hashR());
+		EXPECT_EQ(4978332106395442344, tuple.lHash());
+		EXPECT_EQ(459406847117771879, tuple.rHash());
 	}
 }
 
@@ -577,7 +577,7 @@ TEST_F(db_TuplesTest, store) {
 				attrs,
 				l_principal_id, r_principal_id,
 				_id, _rev,
-				_hash_l, _hash_r,
+				_l_hash, _r_hash,
 				_rid_l, _rid_r
 			from tuples
 			where _id = $1::text;
@@ -599,8 +599,8 @@ TEST_F(db_TuplesTest, store) {
 			 rPrincipalId,
 			 _id,
 			 _rev,
-			 _hashL,
-			 _hashR,
+			 _lHash,
+			 _rHash,
 			 _ridL,
 			 _ridR] =
 				res[0]
@@ -633,8 +633,8 @@ TEST_F(db_TuplesTest, store) {
 		EXPECT_EQ(tuple.rPrincipalId(), rPrincipalId);
 		EXPECT_EQ(tuple.id(), _id);
 		EXPECT_EQ(tuple.rev(), _rev);
-		EXPECT_EQ(tuple.hashL(), _hashL);
-		EXPECT_EQ(tuple.hashR(), _hashR);
+		EXPECT_EQ(tuple.lHash(), _lHash);
+		EXPECT_EQ(tuple.rHash(), _rHash);
 		EXPECT_EQ(tuple.ridL(), _ridL);
 		EXPECT_EQ(tuple.ridR(), _ridR);
 	}

--- a/src/db/tuplets.cpp
+++ b/src/db/tuplets.cpp
@@ -23,14 +23,14 @@ Tuplets TupletsList(
 
 	if (left) {
 		hv      = left->hash();
-		hash    = "_hash_r";
+		hash    = "_r_hash";
 		strand  = "null";
-		where  += " and _hash_l = $2::bigint";
+		where  += " and _l_hash = $2::bigint";
 	} else if (right) {
 		hv      = right->hash();
-		hash    = "_hash_l";
+		hash    = "_l_hash";
 		strand  = "strand";
-		where  += " and _hash_r = $2::bigint";
+		where  += " and _r_hash = $2::bigint";
 	} else {
 		throw err::DbTupletsInvalidListArgs();
 	}

--- a/src/db/tuplets.cpp
+++ b/src/db/tuplets.cpp
@@ -1,0 +1,74 @@
+#include "tuplets.h"
+
+#include <fmt/core.h>
+
+#include "err/errors.h"
+
+namespace db {
+Tuplet::Tuplet(const pg::row_t &r) :
+	_hash(r["_hash"].as<std::int64_t>()), _id(r["_id"].as<std::string>()),
+	_relation(r["relation"].as<std::string>()), _strand(r["strand"].as<strand_t>()) {}
+
+Tuplets TupletsList(
+	std::string_view spaceId, std::optional<Tuple::Entity> left, std::optional<Tuple::Entity> right,
+	std::optional<std::string_view> relation, std::uint16_t count) {
+
+	if (left && right) {
+		throw err::DbTupletsInvalidListArgs();
+	}
+
+	std::int64_t hv;
+	std::string  hash, strand;
+	std::string  where = "where space_id = $1::text";
+
+	if (left) {
+		hv      = left->hash();
+		hash    = "_hash_r";
+		strand  = "null";
+		where  += " and _hash_l = $2::bigint";
+	} else if (right) {
+		hv      = right->hash();
+		hash    = "_hash_l";
+		strand  = "strand";
+		where  += " and _hash_r = $2::bigint";
+	} else {
+		throw err::DbTupletsInvalidListArgs();
+	}
+
+	if (relation) {
+		where += " and relation = $3::text";
+	}
+
+	const std::string qry = fmt::format(
+		R"(
+			select
+				_id,
+				{} as _hash,
+				relation,
+				{} as strand
+			from tuples
+			{}
+			order by _hash desc
+			limit {:d}
+		)",
+		hash,
+		strand,
+		where,
+		count);
+
+	db::pg::result_t res;
+	if (relation) {
+		res = pg::exec(qry, spaceId, hv, relation);
+	} else {
+		res = pg::exec(qry, spaceId, hv);
+	}
+
+	Tuplets tuplets;
+	tuplets.reserve(res.affected_rows());
+	for (const auto &r : res) {
+		tuplets.emplace_back(r);
+	}
+
+	return tuplets;
+}
+} // namespace db

--- a/src/db/tuplets.h
+++ b/src/db/tuplets.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "pg.h"
+#include "tuples.h"
+
+namespace db {
+class Tuplet {
+public:
+	using strand_t = std::optional<std::string>;
+
+	Tuplet(const pg::row_t &r);
+
+	const std::int64_t &hash() const noexcept { return _hash; }
+	const std::string  &id() const noexcept { return _id; }
+	const std::string  &relation() const noexcept { return _relation; }
+	const strand_t     &strand() const noexcept { return _strand; }
+
+private:
+	std::int64_t _hash;
+	std::string  _id;
+	std::string  _relation;
+	strand_t     _strand;
+};
+
+using Tuplets = std::vector<Tuplet>;
+
+Tuplets TupletsList(
+	std::string_view spaceId, std::optional<Tuple::Entity> left, std::optional<Tuple::Entity> right,
+	std::optional<std::string_view> relation = std::nullopt, std::uint16_t count = 10);
+} // namespace db

--- a/src/db/tuplets_test.cpp
+++ b/src/db/tuplets_test.cpp
@@ -1,0 +1,140 @@
+#include <gtest/gtest.h>
+
+#include "err/errors.h"
+
+#include "testing.h"
+#include "tuplets.h"
+
+class db_TupletsTest : public testing::Test {
+protected:
+	static void SetUpTestSuite() {
+		db::testing::setup();
+
+		// Clear data
+		db::pg::exec("truncate table tuples;");
+	}
+
+	void SetUp() {
+		// Clear data from each test
+		db::pg::exec("delete from tuples;");
+	}
+
+	static void TearDownTestSuite() { db::testing::teardown(); }
+};
+
+TEST_F(db_TupletsTest, list) {
+	// Seed tuple to check other tests are only returning expected results
+	db::Tuple tuple({
+		.lEntityId   = "left",
+		.lEntityType = "db_TupletsTest.list",
+		.relation    = "relation",
+		.rEntityId   = "right",
+		.rEntityType = "db_TupletsTest.list",
+		.strand      = "strand",
+	});
+	ASSERT_NO_THROW(tuple.store());
+
+	// Success: list right
+	{
+		db::Tuple tuple({
+			.lEntityId   = "left",
+			.lEntityType = "db_TupletsTest.list-right",
+			.relation    = "relation",
+			.rEntityId   = "right",
+			.rEntityType = "db_TupletsTest.list",
+			.strand      = "strand",
+		});
+		ASSERT_NO_THROW(tuple.store());
+
+		db::Tuplets results;
+		ASSERT_NO_THROW(
+			results =
+				db::TupletsList(tuple.spaceId(), {{tuple.lEntityType(), tuple.lEntityId()}}, {}));
+
+		ASSERT_EQ(1, results.size());
+
+		const auto &actual = results.front();
+		EXPECT_EQ(tuple.hashR(), actual.hash());
+		EXPECT_EQ(tuple.id(), actual.id());
+		EXPECT_EQ(tuple.relation(), actual.relation());
+		EXPECT_FALSE(actual.strand());
+	}
+
+	// Success: list left
+	{
+		db::Tuple tuple({
+			.lEntityId   = "left",
+			.lEntityType = "db_TupletsTest.list",
+			.relation    = "relation",
+			.rEntityId   = "right",
+			.rEntityType = "db_TupletsTest.list-left",
+			.strand      = "strand",
+		});
+		ASSERT_NO_THROW(tuple.store());
+
+		db::Tuplets results;
+		ASSERT_NO_THROW(
+			results =
+				db::TupletsList(tuple.spaceId(), {}, {{tuple.rEntityType(), tuple.rEntityId()}}));
+
+		ASSERT_EQ(1, results.size());
+
+		const auto &actual = results.front();
+		EXPECT_EQ(tuple.hashL(), actual.hash());
+		EXPECT_EQ(tuple.id(), actual.id());
+		EXPECT_EQ(tuple.relation(), actual.relation());
+		EXPECT_EQ(tuple.strand(), actual.strand());
+	}
+
+	// Success: list with relation
+	{
+		db::Tuples tuples({
+			{{
+				.lEntityId   = "left",
+				.lEntityType = "db_TupletsTest.list-with_relation",
+				.relation    = "relation[0]",
+				.rEntityId   = "right",
+				.rEntityType = "db_TupletsTest.list-with_relation",
+				.strand      = "strand",
+			}},
+			{{
+				.lEntityId   = "left",
+				.lEntityType = "db_TupletsTest.list-with_relation",
+				.relation    = "relation[1]",
+				.rEntityId   = "right",
+				.rEntityType = "db_TupletsTest.list-with_relation",
+				.strand      = "strand",
+			}},
+		});
+
+		for (auto &t : tuples) {
+			ASSERT_NO_THROW(t.store());
+		}
+
+		db::Tuplets results;
+		ASSERT_NO_THROW(
+			results = db::TupletsList(
+				tuple.spaceId(),
+				{},
+				{{tuples[0].rEntityType(), tuples[0].rEntityId()}},
+				tuples[0].relation()));
+
+		ASSERT_EQ(1, results.size());
+
+		const auto &actual = results.front();
+		EXPECT_EQ(tuples[0].hashL(), actual.hash());
+		EXPECT_EQ(tuples[0].id(), actual.id());
+		EXPECT_EQ(tuples[0].relation(), actual.relation());
+		EXPECT_EQ(tuples[0].strand(), actual.strand());
+	}
+
+	// Error: invalid args
+	{
+		EXPECT_THROW(
+			db::TupletsList({}, db::Tuple::Entity(), db::Tuple::Entity()),
+			err::DbTupletsInvalidListArgs);
+
+		EXPECT_THROW(
+			db::TupletsList({}, std::nullopt, std::nullopt), err::DbTupletsInvalidListArgs);
+	}
+}

--- a/src/db/tuplets_test.cpp
+++ b/src/db/tuplets_test.cpp
@@ -54,7 +54,7 @@ TEST_F(db_TupletsTest, list) {
 		ASSERT_EQ(1, results.size());
 
 		const auto &actual = results.front();
-		EXPECT_EQ(tuple.hashR(), actual.hash());
+		EXPECT_EQ(tuple.rHash(), actual.hash());
 		EXPECT_EQ(tuple.id(), actual.id());
 		EXPECT_EQ(tuple.relation(), actual.relation());
 		EXPECT_FALSE(actual.strand());
@@ -80,7 +80,7 @@ TEST_F(db_TupletsTest, list) {
 		ASSERT_EQ(1, results.size());
 
 		const auto &actual = results.front();
-		EXPECT_EQ(tuple.hashL(), actual.hash());
+		EXPECT_EQ(tuple.lHash(), actual.hash());
 		EXPECT_EQ(tuple.id(), actual.id());
 		EXPECT_EQ(tuple.relation(), actual.relation());
 		EXPECT_EQ(tuple.strand(), actual.strand());
@@ -122,7 +122,7 @@ TEST_F(db_TupletsTest, list) {
 		ASSERT_EQ(1, results.size());
 
 		const auto &actual = results.front();
-		EXPECT_EQ(tuples[0].hashL(), actual.hash());
+		EXPECT_EQ(tuples[0].lHash(), actual.hash());
 		EXPECT_EQ(tuples[0].id(), actual.id());
 		EXPECT_EQ(tuples[0].relation(), actual.relation());
 		EXPECT_EQ(tuples[0].strand(), actual.strand());

--- a/src/err/errors.h
+++ b/src/err/errors.h
@@ -22,7 +22,8 @@ using DbTupleNotFound      = basic_error<"sentium:1.4.3.404", "Tuple not found">
 using DbTuplesInvalidListArgs =
 	basic_error<"sentium:1.4.4.400", "Invalid arguments for listing tuples">;
 
-using DbTupletsInvalidListArgs = basic_error<"sentium:1.4.5.400", "Invalid arguments for listing tuplets">;
+using DbTupletsInvalidListArgs =
+	basic_error<"sentium:1.4.5.400", "Invalid arguments for listing tuplets">;
 
 using RpcPrincipalsAlreadyExists = basic_error<"sentium:2.1.1.409", "Principal already exists">;
 using RpcPrincipalsNotFound      = basic_error<"sentium:2.1.2.404", "Principal not found">;

--- a/src/err/errors.h
+++ b/src/err/errors.h
@@ -22,7 +22,7 @@ using DbTupleNotFound      = basic_error<"sentium:1.4.3.404", "Tuple not found">
 using DbTuplesInvalidListArgs =
 	basic_error<"sentium:1.4.4.400", "Invalid arguments for listing tuples">;
 
-using DbTupletsInvalidListArgs = basic_error<"", "Invalid arguments for listing tuplets">;
+using DbTupletsInvalidListArgs = basic_error<"sentium:1.4.5.400", "Invalid arguments for listing tuplets">;
 
 using RpcPrincipalsAlreadyExists = basic_error<"sentium:2.1.1.409", "Principal already exists">;
 using RpcPrincipalsNotFound      = basic_error<"sentium:2.1.2.404", "Principal not found">;

--- a/src/err/errors.h
+++ b/src/err/errors.h
@@ -22,6 +22,8 @@ using DbTupleNotFound      = basic_error<"sentium:1.4.3.404", "Tuple not found">
 using DbTuplesInvalidListArgs =
 	basic_error<"sentium:1.4.4.400", "Invalid arguments for listing tuples">;
 
+using DbTupletsInvalidListArgs = basic_error<"", "Invalid arguments for listing tuplets">;
+
 using RpcPrincipalsAlreadyExists = basic_error<"sentium:2.1.1.409", "Principal already exists">;
 using RpcPrincipalsNotFound      = basic_error<"sentium:2.1.2.404", "Principal not found">;
 

--- a/src/svc/relations.cpp
+++ b/src/svc/relations.cpp
@@ -565,6 +565,10 @@ Impl::spot_t Impl::spot(
 				auto tl = db::Tuple::retrieve(i->id());
 				auto tr = db::Tuple::retrieve(j->id());
 
+				cost += 2;
+
+				// Compare text (unhashed) values to avoid any false positives due to hash
+				// collisions
 				if (tl.rEntityType() == tr.lEntityType() && tl.rEntityId() == tr.lEntityId()) {
 					return {cost, db::Tuple(tl, tr)};
 				}

--- a/src/svc/relations.cpp
+++ b/src/svc/relations.cpp
@@ -6,6 +6,7 @@
 #include <google/protobuf/util/json_util.h>
 #include <google/rpc/code.pb.h>
 
+#include "db/tuplets.h"
 #include "encoding/b32.h"
 #include "err/errors.h"
 #include "sentium/detail/pagination.pb.h"
@@ -551,24 +552,34 @@ Impl::spot_t Impl::spot(
 
 	std::int32_t cost = 0;
 
-	auto t1 = db::ListTuplesRight(spaceId, left, {}, {}, limit);
-	auto t2 = db::ListTuplesLeft(spaceId, right, relation, {}, limit);
+	auto t1 = db::TupletsList(spaceId, left, {}, {}, limit);
+	auto t2 = db::TupletsList(spaceId, {}, right, relation, limit);
 
 	auto i = t1.cbegin();
 	auto j = t2.cbegin();
 	while (i != t1.cend() && j != t2.cend()) {
 		cost++;
-		auto r = i->rEntityId().compare(j->lEntityId());
 
-		if (r == 0) {
-			if (i->relation() == j->strand() && i->rEntityType() == j->lEntityType()) {
-				return {cost, db::Tuple(*i, *j)};
+		if (i->hash() == j->hash()) {
+			if (i->relation() == j->strand()) {
+				auto tl = db::Tuple::retrieve(i->id());
+				auto tr = db::Tuple::retrieve(j->id());
+
+				if (tl.rEntityType() == tr.lEntityType() && tl.rEntityId() == tr.lEntityId()) {
+					return {cost, db::Tuple(tl, tr)};
+				}
+			}
+
+			if (j != t2.cend() - 1) {
+				j++;
 			} else {
 				i++;
 			}
+
+			continue;
 		}
 
-		if (r > 0) {
+		if (i->hash() > j->hash()) {
 			i++;
 		} else {
 			j++;

--- a/src/svc/relations_test.cpp
+++ b/src/svc/relations_test.cpp
@@ -233,7 +233,7 @@ TEST_F(svc_RelationsTest, Check) {
 			EXPECT_EQ(grpcxx::status::code_t::ok, result.status.code());
 			ASSERT_TRUE(result.response);
 			EXPECT_EQ(true, result.response->found());
-			EXPECT_EQ(2, result.response->cost());
+			EXPECT_EQ(3, result.response->cost());
 			ASSERT_TRUE(result.response->has_tuple());
 
 			auto &actual = result.response->tuple();

--- a/src/svc/relations_test.cpp
+++ b/src/svc/relations_test.cpp
@@ -233,7 +233,7 @@ TEST_F(svc_RelationsTest, Check) {
 			EXPECT_EQ(grpcxx::status::code_t::ok, result.status.code());
 			ASSERT_TRUE(result.response);
 			EXPECT_EQ(true, result.response->found());
-			EXPECT_EQ(3, result.response->cost());
+			EXPECT_EQ(5, result.response->cost());
 			ASSERT_TRUE(result.response->has_tuple());
 
 			auto &actual = result.response->tuple();


### PR DESCRIPTION
Comparing `int64`s (8 bytes fixed length) is more efficient than comparing variable length strings. This change attempts to utilises this efficiency to reduce latencies when checking relations (specially when using `set` strategy). 

A pre-computed `int64` hash values for tuples' left and right entities are stored in the DB along with an index specifically created to yield index only scans when retrieving data for the `set` strategy. This index is also used to achieve a favourable query plan when listing tuples for the `graph` strategy.

Additional computations, hash data and index writes results in slightly slower writes but better reads.

## Benchmarks

### b1. Spot algorithm

```
Load Average: 1.84, 2.01, 2.03
------------------------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------------------
bm_spot_intersection/8                 160 ns          160 ns      4358872 comparisons=93.6867M/s ops=6.24578M/s
bm_spot_intersection/64               1848 ns         1845 ns       378323 comparisons=68.8411M/s ops=542.056k/s
bm_spot_intersection/512             14806 ns        14786 ns        47356 comparisons=69.185M/s ops=67.6295k/s
bm_spot_intersection/4096           118449 ns       118280 ns         5911 comparisons=69.251M/s ops=8.45453k/s
bm_spot_intersection/8192           236818 ns       236432 ns         2948 comparisons=69.2926M/s ops=4.22954k/s
bm_spot_intersection_int64/8          21.3 ns         21.3 ns     32957461 comparisons=705.842M/s ops=47.0561M/s
bm_spot_intersection_int64/64          371 ns          370 ns      2101030 comparisons=343.293M/s ops=2.7031M/s
bm_spot_intersection_int64/512        2725 ns         2721 ns       257593 comparisons=375.953M/s ops=367.501k/s
bm_spot_intersection_int64/4096      21324 ns        21291 ns        32302 comparisons=384.722M/s ops=46.9689k/s
bm_spot_intersection_int64/8192      42979 ns        42921 ns        16160 comparisons=381.697M/s ops=23.2984k/s

```

### b2. Check relations using `set` strategy 

<details>
<summary>Before</Summary>

```
Load Average: 3.00, 2.84, 2.78
--------------------------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------
bm_relations/check_set/8        196064 ns        35581 ns        19489 comparisons=56.2097k/s ops=28.1049k/s
bm_relations/check_set/64      1003334 ns       141064 ns         4932 comparisons=14.178k/s ops=7.08899k/s
bm_relations/check_set/512     8286319 ns       948926 ns          741 comparisons=2.10765k/s ops=1.05382k/s
bm_relations/check_set/4096   77921608 ns      7398617 ns           94 comparisons=270.321/s ops=135.16/s
bm_relations/check_set/8192  163626824 ns     15178500 ns           46 comparisons=131.765/s ops=65.8827/s
```
</details>

```
Load Average: 1.87, 2.05, 2.36
--------------------------------------------------------------------------------------
Benchmark                            Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------
bm_relations/check_set/8        256227 ns        38917 ns        10000 comparisons=308.351k/s ops=25.6959k/s
bm_relations/check_set/64       336578 ns        64024 ns        11156 comparisons=281.145k/s ops=15.6192k/s
bm_relations/check_set/512      898412 ns       277908 ns         2510 comparisons=892.38k/s ops=3.59831k/s
bm_relations/check_set/4096    5327552 ns      1957718 ns          358 comparisons=77.6414k/s ops=510.799/s
bm_relations/check_set/8192   10625457 ns      3873122 ns          181 comparisons=58.8672k/s ops=258.19/s
```

### b3. Check relations using `graph` strategy 
<details>
<summary>Before</summary>

```
Load Average: 5.95, 3.78, 3.13
-------------------------------------------------------------------------------------------
Benchmark                                 Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------
bm_relations/check_graph/4/128       639445 ns        57550 ns        12220 ops=17.3762k/s vertices=104.257k/s
bm_relations/check_graph/8/128      1501169 ns        91245 ns         7583 ops=10.9595k/s vertices=109.595k/s
bm_relations/check_graph/32/128    14705872 ns       330233 ns         1000 ops=3.02816k/s vertices=102.958k/s
bm_relations/check_graph/4/512      1451171 ns        58645 ns        11816 ops=17.0517k/s vertices=102.31k/s
bm_relations/check_graph/8/512      4344049 ns        96089 ns         1000 ops=10.407k/s vertices=104.07k/s
bm_relations/check_graph/32/512    53038020 ns       353580 ns          100 ops=2.82821k/s vertices=96.1593k/s
bm_relations/check_graph/4/2048     4869842 ns        61965 ns         1000 ops=16.1381k/s vertices=96.8289k/s
bm_relations/check_graph/8/2048    15515533 ns       106336 ns         1000 ops=9.40415k/s vertices=94.0415k/s
bm_relations/check_graph/32/2048  217419540 ns       709720 ns          100 ops=1.40901k/s vertices=47.9062k/s
```
</details>

```
Load Average: 2.57, 2.33, 2.56
-------------------------------------------------------------------------------------------
Benchmark                                 Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------
bm_relations/check_graph/4/128       424975 ns        60051 ns        11776 ops=16.6526k/s vertices=99.9157k/s
bm_relations/check_graph/8/128       658312 ns        93717 ns         7311 ops=10.6704k/s vertices=106.704k/s
bm_relations/check_graph/32/128     2067346 ns       320007 ns         2165 ops=3.12493k/s vertices=106.248k/s
bm_relations/check_graph/4/512       423596 ns        58971 ns        11884 ops=16.9576k/s vertices=101.746k/s
bm_relations/check_graph/8/512       658667 ns        93952 ns         7430 ops=10.6437k/s vertices=106.437k/s
bm_relations/check_graph/32/512     2091182 ns       328202 ns         2085 ops=3.0469k/s vertices=103.595k/s
bm_relations/check_graph/4/2048      431698 ns        60988 ns        11462 ops=16.3966k/s vertices=98.3795k/s
bm_relations/check_graph/8/2048      680199 ns        98905 ns         7242 ops=10.1107k/s vertices=101.107k/s
bm_relations/check_graph/32/2048    2118427 ns       325959 ns         2195 ops=3.06787k/s vertices=104.307k/s
```

### b4. Create relations 🔻

<details>
<summary>Before</summary>

```
Load Average: 1.53, 2.37, 2.66
------------------------------------------------------------------------------
Benchmark                    Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------
bm_relations/create      89585 ns         7293 ns        95761 ops=137.118k/s writes=137.118k/s
```
</details>

```
Load Average: 1.61, 1.88, 1.98
------------------------------------------------------------------------------
Benchmark                    Time             CPU   Iterations UserCounters...
------------------------------------------------------------------------------
bm_relations/create     102199 ns         7479 ns        93777 ops=133.703k/s writes=133.703k/s
```

## Query plans

### p1. Listing tuplets right

```
explain select
  _id,
  _r_hash as _hash,
  relation,
  null as strand
from tuples
where space_id = '' and _l_hash = 8357126990540548874
order by _hash desc
limit 1000;
                                                QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
 Limit  (cost=0.29..130.18 rows=1000 width=68)
   ->  Index Only Scan Backward using "tuples.idx-rtl" on tuples  (cost=0.29..1064.36 rows=8192 width=68)
         Index Cond: ((space_id = ''::text) AND (_l_hash = '8357126990540548874'::bigint))
```

### p2. Listing tuplets left

```
explain select
  _id,
  _l_hash as _hash,
  relation,
  strand as strand
from tuples
where space_id = '' and _r_hash = 2410070456889820883 and relation = 'reader'
order by _hash desc
limit 1000;
                                                        QUERY PLAN                                                         
---------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.28..8.30 rows=1 width=43)
   ->  Index Only Scan Backward using "tuples.idx-rtl" on tuples  (cost=0.28..8.30 rows=1 width=43)
         Index Cond: ((space_id = ''::text) AND (_r_hash = '2410070456889820883'::bigint) AND (relation = 'reader'::text))
```

### p3. Listing tuples left (with relation)

```
explain select
  space_id,
  strand,
  l_entity_type, l_entity_id,
  relation,
  r_entity_type, r_entity_id,
  attrs,
  l_principal_id, r_principal_id,
  _id, _rev,
  _l_hash, _r_hash,
  _rid_l, _rid_r
from tuples
where
  space_id = ''
  and _r_hash = 1704957511755688144
  and r_entity_type = 'bm_relations.check_graph' and r_entity_id = 'cpg94bbjuspgs1abd9pg'
  and relation = 'reader'
order by l_entity_id desc
limit 1000;
                                                           QUERY PLAN                                                            
---------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=8.46..8.46 rows=1 width=306)
   ->  Sort  (cost=8.46..8.46 rows=1 width=306)
         Sort Key: l_entity_id DESC
         ->  Index Scan using "tuples.idx-rtl" on tuples  (cost=0.42..8.45 rows=1 width=306)
               Index Cond: ((space_id = ''::text) AND (_r_hash = '1704957511755688144'::bigint) AND (relation = 'reader'::text))
               Filter: ((r_entity_type = 'bm_relations.check_graph'::text) AND (r_entity_id = 'cpg94bbjuspgs1abd9pg'::text))
```

### p4. Listing tuples left (without relation)

```
explain select
  space_id,
  strand,
  l_entity_type, l_entity_id,
  relation,
  r_entity_type, r_entity_id,
  attrs,
  l_principal_id, r_principal_id,
  _id, _rev,
  _l_hash, _r_hash,
  _rid_l, _rid_r
from tuples
where
  space_id = ''
  and _r_hash = 7809478143556808948
  and r_entity_type = 'bm_relations.check_graph' and r_entity_id = 'cpg94cjjuspgs1acv98g'
order by l_entity_id desc
limit 1000;
                                                         QUERY PLAN                                                          
-----------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=8.45..8.46 rows=1 width=306)
   ->  Sort  (cost=8.45..8.46 rows=1 width=306)
         Sort Key: l_entity_id DESC
         ->  Index Scan using "tuples.idx-rtl" on tuples  (cost=0.42..8.44 rows=1 width=306)
               Index Cond: ((space_id = ''::text) AND (_r_hash = '7809478143556808948'::bigint))
               Filter: ((r_entity_type = 'bm_relations.check_graph'::text) AND (r_entity_id = 'cpg94cjjuspgs1acv98g'::text))
```

### p5. Listing tuples right

```
explain select
  space_id,
  strand,
  l_entity_type, l_entity_id,
  relation,
  r_entity_type, r_entity_id,
  attrs,
  l_principal_id, r_principal_id,
  _id, _rev,
  _l_hash, _r_hash,
  _rid_l, _rid_r
from tuples
where
  space_id = ''
  and 0 = 0
  and l_entity_type = 'bm_relations.check_graph' and l_entity_id = 'cpgcqn3juspiar5r9esg'
order by r_entity_id desc
limit 1000;
                                                                        QUERY PLAN                                                                         
-----------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=13.79..13.80 rows=4 width=306)
   ->  Sort  (cost=13.79..13.80 rows=4 width=306)
         Sort Key: r_entity_id DESC
         ->  Index Scan using "tuples.unique" on tuples  (cost=0.41..13.75 rows=4 width=306)
               Index Cond: ((space_id = ''::text) AND (l_entity_type = 'bm_relations.check_graph'::text) AND (l_entity_id = 'cpgcqn3juspiar5r9esg'::text))
```